### PR TITLE
chore: fix the "discussions" link

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ This project is licensed under the Apache License 2.0. See [LICENSE.txt](LICENSE
 - **Docker Hardened Images**: [docker.com/products/hardened-images](https://docker.com/products/hardened-images/)
 - **Commercial Support**: [docker.com/support](https://docker.com/support/)
 - **Issue Tracker**: [GitHub Issues](https://github.com/docker-hardened-images/catalog/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/docker-hardened-images/discussion)
+- **Discussions**: [GitHub Discussions](https://github.com/orgs/docker-hardened-images/discussions)
 
 ---
 


### PR DESCRIPTION
The existing link is 404:

<img width="956" height="506" alt="image" src="https://github.com/user-attachments/assets/1a23ebba-6f34-4889-9af7-007bb9696fff" />
