### PR TITLE
restore corepack in node sfw-dev-alpine3.23 images

### DIFF
--- a/image/node/alpine-3.23/20-sfw-dev.yaml
+++ b/image/node/alpine-3.23/20-sfw-dev.yaml
@@ -15,6 +15,7 @@ dates:
   release: "2023-04-18"
   end-of-life: "2026-04-30"
 vars:
+  COREPACK_VERSION: 0.34.6-r0
   NODEJS_VERSION_MAJOR: "20"
   NODEJS_VERSION_MAJOR_MINOR: "20.20"
   SEMVER_MAJOR_MINOR_VERSION: "20.20"
@@ -34,6 +35,7 @@ contents:
     - apk-tools
     - busybox
     - ca-certificates-bundle
+    - corepack=0.34.6-r0
     - coreutils-env
     - git
     - libgcc

--- a/image/node/alpine-3.23/20-sfw-ent-dev.yaml
+++ b/image/node/alpine-3.23/20-sfw-ent-dev.yaml
@@ -15,6 +15,7 @@ dates:
   release: "2023-04-18"
   end-of-life: "2026-04-30"
 vars:
+  COREPACK_VERSION: 0.34.6-r0
   NODEJS_VERSION_MAJOR: "20"
   NODEJS_VERSION_MAJOR_MINOR: "20.20"
   SEMVER_MAJOR_MINOR_VERSION: "20.20"
@@ -34,6 +35,7 @@ contents:
     - apk-tools
     - busybox
     - ca-certificates-bundle
+    - corepack=0.34.6-r0
     - coreutils-env
     - git
     - libgcc

--- a/image/node/alpine-3.23/22-sfw-dev.yaml
+++ b/image/node/alpine-3.23/22-sfw-dev.yaml
@@ -15,6 +15,7 @@ dates:
   release: "2024-04-24"
   end-of-life: "2027-04-30"
 vars:
+  COREPACK_VERSION: 0.34.6-r0
   NODEJS_VERSION_MAJOR: "22"
   NODEJS_VERSION_MAJOR_MINOR: "22.22"
   SEMVER_MAJOR_MINOR_VERSION: "22.22"
@@ -34,6 +35,7 @@ contents:
     - apk-tools
     - busybox
     - ca-certificates-bundle
+    - corepack=0.34.6-r0
     - coreutils-env
     - git
     - libgcc

--- a/image/node/alpine-3.23/22-sfw-ent-dev.yaml
+++ b/image/node/alpine-3.23/22-sfw-ent-dev.yaml
@@ -15,6 +15,7 @@ dates:
   release: "2024-04-24"
   end-of-life: "2027-04-30"
 vars:
+  COREPACK_VERSION: 0.34.6-r0
   NODEJS_VERSION_MAJOR: "22"
   NODEJS_VERSION_MAJOR_MINOR: "22.22"
   SEMVER_MAJOR_MINOR_VERSION: "22.22"
@@ -34,6 +35,7 @@ contents:
     - apk-tools
     - busybox
     - ca-certificates-bundle
+    - corepack=0.34.6-r0
     - coreutils-env
     - git
     - libgcc

--- a/image/node/alpine-3.23/24-sfw-dev.yaml
+++ b/image/node/alpine-3.23/24-sfw-dev.yaml
@@ -15,6 +15,7 @@ dates:
   release: "2025-05-06"
   end-of-life: "2028-04-30"
 vars:
+  COREPACK_VERSION: 0.34.6-r0
   NODEJS_VERSION_MAJOR: "24"
   NODEJS_VERSION_MAJOR_MINOR: "24.14"
   SEMVER_MAJOR_MINOR_VERSION: "24.14"
@@ -34,6 +35,7 @@ contents:
     - apk-tools
     - busybox
     - ca-certificates-bundle
+    - corepack=0.34.6-r0
     - coreutils-env
     - git
     - libgcc

--- a/image/node/alpine-3.23/24-swf-ent-dev.yaml
+++ b/image/node/alpine-3.23/24-swf-ent-dev.yaml
@@ -15,6 +15,7 @@ dates:
   release: "2025-05-06"
   end-of-life: "2028-04-30"
 vars:
+  COREPACK_VERSION: 0.34.6-r0
   NODEJS_VERSION_MAJOR: "24"
   NODEJS_VERSION_MAJOR_MINOR: "24.14"
   SEMVER_MAJOR_MINOR_VERSION: "24.14"
@@ -34,6 +35,7 @@ contents:
     - apk-tools
     - busybox
     - ca-certificates-bundle
+    - corepack=0.34.6-r0
     - coreutils-env
     - git
     - libgcc

--- a/image/node/alpine-3.23/25-sfw-dev.yaml
+++ b/image/node/alpine-3.23/25-sfw-dev.yaml
@@ -15,6 +15,7 @@ dates:
   release: "2025-10-15"
   end-of-life: "2026-06-01"
 vars:
+  COREPACK_VERSION: 0.34.6-r0
   NODEJS_VERSION_MAJOR: "25"
   NODEJS_VERSION_MAJOR_MINOR: "25.8"
   SEMVER_MAJOR_MINOR_VERSION: "25.8"
@@ -34,6 +35,7 @@ contents:
     - apk-tools
     - busybox
     - ca-certificates-bundle
+    - corepack=0.34.6-r0
     - coreutils-env
     - git
     - libgcc

--- a/image/node/alpine-3.23/25-sfw-ent-dev.yaml
+++ b/image/node/alpine-3.23/25-sfw-ent-dev.yaml
@@ -15,6 +15,7 @@ dates:
   release: "2025-10-15"
   end-of-life: "2026-06-01"
 vars:
+  COREPACK_VERSION: 0.34.6-r0
   NODEJS_VERSION_MAJOR: "25"
   NODEJS_VERSION_MAJOR_MINOR: "25.8"
   SEMVER_MAJOR_MINOR_VERSION: "25.8"
@@ -34,6 +35,7 @@ contents:
     - apk-tools
     - busybox
     - ca-certificates-bundle
+    - corepack=0.34.6-r0
     - coreutils-env
     - git
     - libgcc


### PR DESCRIPTION
## Description

restore corepack in node sfw-dev images.

-> as corepack is still included in sfw-dev-debian13 + it was included here as well before this commit: https://github.com/docker-hardened-images/catalog/commit/e1f63280dd6395bd387985714f7030580c89938e

## Type of Change

- [ ] New image
- [ ] New Helm chart
- [ ] New package
- [ ] Documentation improvement or correction
- [ ] Example configuration or use case
- [ ] Community tooling or script
- [ ] Website or catalog enhancement
- [x] Bug fix
- [ ] Other (please describe):
