### PR TITLE
Fix envoy-gateway chart to use DHI envoy image for data plane

### DIFF
--- a/chart/envoy-gateway/config/values.yaml
+++ b/chart/envoy-gateway/config/values.yaml
@@ -6,6 +6,18 @@ global:
     ratelimit:
       image: ${envoy-ratelimit.registry}/${envoy-ratelimit.repository}:${envoy-ratelimit.tag}@${envoy-ratelimit.digest}
 
+config:
+  envoyGateway:
+    provider:
+      type: Kubernetes
+      kubernetes:
+        envoyDeployment:
+          container:
+            image: ${envoy.registry}/${envoy.repository}:${envoy.tag}@${envoy.digest}
+          # NOTE: Users must also configure imagePullSecrets on their EnvoyProxy CR
+          # to allow proxy pods to pull from dhi.io. For example:
+          #   spec.provider.kubernetes.envoyDeployment.pod.imagePullSecrets
+
 deployment:
   envoyGateway:
     securityContext:

--- a/chart/envoy-gateway/guides.md
+++ b/chart/envoy-gateway/guides.md
@@ -71,6 +71,47 @@ Note: As you might have noticed, upstream sets image pull secret slightly differ
 Replace `<version>` accordingly. If the chart is in your own registry or repository, replace `dhi.io` with your own
 registry and namespace. Replace `helm-pull-secret` with the name of the image pull secret you created earlier.
 
+#### Step 3a: Configure imagePullSecrets for data plane proxy pods
+
+The Helm chart configures `imagePullSecrets` for the envoy-gateway controller, but the data plane envoy proxy pods are
+created dynamically by the controller, not by Helm. These proxy pods also need credentials to pull from `dhi.io`.
+
+To configure this, add `imagePullSecrets` to your `EnvoyProxy` custom resource:
+
+```yaml
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: my-proxy-config
+  namespace: <namespace>
+spec:
+  provider:
+    kubernetes:
+      envoyDeployment:
+        pod:
+          imagePullSecrets:
+            - name: helm-pull-secret
+```
+
+Then reference this `EnvoyProxy` in your `GatewayClass`:
+
+```yaml
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: eg
+spec:
+  controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: my-proxy-config
+    namespace: <namespace>
+```
+
+Without this configuration, the proxy pods will fail with `ErrImagePull` when attempting to pull the hardened envoy
+image from `dhi.io`.
+
 #### Step 4: Verify the installation
 
 The deployment's pods should show up and running almost immediately:

--- a/chart/envoy-gateway/helm/1.yaml
+++ b/chart/envoy-gateway/helm/1.yaml
@@ -14,6 +14,7 @@ vars:
   DHI_REGISTRY: dhi.io
   DHI_SKIP_CONTEXT_COPY: "true"
   ENVOY_GATEWAY_IMAGE_REFERENCE: dhi/envoy-gateway:1.7.1-debian13@sha256:561df43ebc3c1296df650b3771989897c07fd39039be4260a4f00c0428b50273
+  ENVOY_IMAGE_REFERENCE: dhi/envoy:1.37.1-debian13@sha256:034dc62dc83b95d7817fe19851de847efa1e03f972e71c227e01abb2a2515878
   ENVOY_RATELIMIT_IMAGE_REFERENCE: dhi/envoy-ratelimit:05c08d0394737a24729e01519629420a4d86b865-debian13@sha256:e1b27e77b99eb5988d1fe78c13ca7cee44ca8fcd997e943e5af557d8db026b30
   HELM_REFERENCE: dhi/helm:3.20.1-debian13-dev@sha256:a2c1b2e1c9d947d8feabde6c5ae3d2f9b1f0883a4d6cd01d49ccb0e509465920
   SEMVER_MAJOR_MINOR_VERSION: "1.7"
@@ -42,6 +43,8 @@ contents:
               images:
                 - name: envoy-gateway
                   ref: dhi/envoy-gateway:1.7.1-debian13@sha256:561df43ebc3c1296df650b3771989897c07fd39039be4260a4f00c0428b50273
+                - name: envoy
+                  ref: dhi/envoy:1.37.1-debian13@sha256:034dc62dc83b95d7817fe19851de847efa1e03f972e71c227e01abb2a2515878
                 - name: envoy-ratelimit
                   ref: dhi/envoy-ratelimit:05c08d0394737a24729e01519629420a4d86b865-debian13@sha256:e1b27e77b99eb5988d1fe78c13ca7cee44ca8fcd997e943e5af557d8db026b30
               name: envoy-gateway-chart


### PR DESCRIPTION
## Description

The envoy-gateway Helm chart overrides the control plane (`envoy-gateway`) and `ratelimit` images with DHI variants, but the data plane envoy proxy pods still pull `docker.io/envoyproxy/envoy:distroless-*` from upstream. This adds the DHI `envoy` image as the default proxy image via the `config.envoyGateway.provider.kubernetes.envoyDeployment.container.image` config path.

### Tested

Verified on a live OKE cluster:
- `helm template` confirms the image renders correctly in the EnvoyGateway ConfigMap
- After `helm upgrade`, the ConfigMap contains the correct `envoyDeployment.container.image`
- New proxy pods successfully run with `dhi.io/envoy:1.37.1-debian13`

### Note on imagePullSecrets

The proxy pods are created dynamically by the envoy-gateway controller, not by the Helm chart directly. Users with private registry auth will also need to configure `imagePullSecrets` on their `EnvoyProxy` CR for the proxy pods to pull from `dhi.io`. A comment has been added to `values.yaml` noting this. The guides may need a corresponding update.

## Type of Change

- [ ] New image
- [ ] New Helm chart
- [ ] New package
- [ ] Documentation improvement or correction
- [ ] Example configuration or use case
- [ ] Community tooling or script
- [ ] Website or catalog enhancement
- [x] Bug fix
- [ ] Other (please describe):

## Related Issues

Fixes #253

## Changes Made

- Added `ENVOY_IMAGE_REFERENCE` var and `envoy` image to `chart/envoy-gateway/helm/1.yaml`
- Added `config.envoyGateway.provider.kubernetes.envoyDeployment.container.image` override to `chart/envoy-gateway/config/values.yaml`
- Added comment noting users must configure `imagePullSecrets` on their `EnvoyProxy` CR

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

## Screenshots (if applicable)

N/A

## Checklist

- [x] My changes follow the repository's style and conventions
- [x] I have updated documentation as needed
- [x] My commit messages are clear and descriptive

---

> **By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**