### PR TITLE
fix: Add libcurl3-gnutls

### DIFF
--- a/image/git/debian-13/2-dev.yaml
+++ b/image/git/debian-13/2-dev.yaml
@@ -39,6 +39,7 @@ contents:
     - git=1:2.47.3-0+deb13u1
     - grep
     - libc-bin
+    - libcurl3-gnutls
     - liberror-perl
     - libpcre2-8-0
     - mawk

--- a/image/git/debian-13/2.yaml
+++ b/image/git/debian-13/2.yaml
@@ -30,6 +30,7 @@ contents:
     - ca-certificates
     - curl
     - git=1:2.47.3-0+deb13u1
+    - libcurl3-gnutls
     - liberror-perl
     - libpcre2-8-0
     - perl


### PR DESCRIPTION
libcurl3-gnutls provides libcurl-gnutls.so.4 with the CURL_GNUTLS_3 symbol version that git-remote-https is linked against. Without it, any HTTPS git operation (clone, fetch, ls-remote, push) fails.