### PR TITLE
[ruby] Remove Rust build toolchain from 4.0.x runtime image

### DIFF
--- a/image/ruby/debian-13/3.3.yaml
+++ b/image/ruby/debian-13/3.3.yaml
@@ -226,6 +226,13 @@ contents:
             rm -f /usr/local/bin/ri
             rm -f /usr/local/bin/syntax_suggest
             rm -f /usr/local/bin/typeprof
+        - name: cleanup-rust
+          runs: |
+            set -eux -o pipefail
+            rm -rf /usr/local/lib/rustlib
+            rm -f  /usr/local/lib/libLLVM*.so*
+            rm -f  /usr/local/lib/librustc_driver-*.so
+            rm -f  /usr/local/bin/rustc
       paths:
         - type: directory
           path: /tmp

--- a/image/ruby/debian-13/3.4.yaml
+++ b/image/ruby/debian-13/3.4.yaml
@@ -228,6 +228,13 @@ contents:
             rm -f /usr/local/bin/ri
             rm -f /usr/local/bin/syntax_suggest
             rm -f /usr/local/bin/typeprof
+        - name: cleanup-rust
+          runs: |
+            set -eux -o pipefail
+            rm -rf /usr/local/lib/rustlib
+            rm -f  /usr/local/lib/libLLVM*.so*
+            rm -f  /usr/local/lib/librustc_driver-*.so
+            rm -f  /usr/local/bin/rustc
       paths:
         - type: directory
           path: /tmp

--- a/image/ruby/debian-13/4.0.yaml
+++ b/image/ruby/debian-13/4.0.yaml
@@ -233,6 +233,13 @@ contents:
             rm -f /usr/local/bin/ri
             rm -f /usr/local/bin/syntax_suggest
             rm -f /usr/local/bin/typeprof
+        - name: cleanup-rust
+          runs: |
+            set -eux -o pipefail
+            rm -rf /usr/local/lib/rustlib
+            rm -f  /usr/local/lib/libLLVM*.so*
+            rm -f  /usr/local/lib/librustc_driver-*.so
+            rm -f  /usr/local/bin/rustc
       paths:
         - type: directory
           path: /tmp


### PR DESCRIPTION
The debian-13 runtime images for Ruby 3.3, 3.4, and 4.0 ship ~599MB of Rust
compiler toolchain that is only needed at build time to compile Ruby with YJIT
(`--enable-yjit`) and has no runtime dependency.

**Root cause:** introduced in c0b0826 (_feat(ruby): enable YJIT on Debian 13_,
#36236), which added `--enable-yjit` to the Ruby `./configure` flags and
mounted the `dhi.io/rust` image as a build artifact with
`includes: usr/local/lib`. Because the `outputs` section exports all of
`/usr/local` to the final image, the entire Rust toolchain is carried
alongside the Ruby runtime files:

```
/usr/local/lib/rustlib/                       334MB
/usr/local/lib/libLLVM.so.22.1-rust-1.95.0    158MB
/usr/local/lib/librustc_driver-...so           107MB
/usr/local/bin/rustc                            ~2MB
```

**Evidence:** `ldd /usr/local/bin/ruby` shows no Rust runtime dependency —
only `libruby.so`, `libc`, `libm`, `libz`, `libgmp`, `libjemalloc`,
`libgcc_s`, `libstdc++`, `libcrypt`.

For comparison, `dhi-ruby:4.0.1` (pre-YJIT, pre-c0b0826) has an 85MB
`build ruby` layer. The 4.0.4 runtime image has a 723MB layer — the 638MB
delta is entirely Rust toolchain.

Note: the fix cannot be applied downstream — Docker layer immutability means
bytes in the base layer remain counted, and the CIS-hardened image runs as
`nonroot` (UID 65532) which cannot delete root-owned Rust files.

**Fix:** adds a `cleanup-rust` pipeline step to `3.3.yaml`, `3.4.yaml`, and
`4.0.yaml` that removes the four Rust-owned entries from `/usr/local` before
the `outputs` section copies it into the final image:

```
rm -rf /usr/local/lib/rustlib
rm -f  /usr/local/lib/libLLVM*.so*
rm -f  /usr/local/lib/librustc_driver-*.so
rm -f  /usr/local/bin/rustc
```

**Expected result:** runtime images drop from ~795MB to ~196MB.
