### PR TITLE
redis: add libcrypt1 to 8.8-compat runtime packages

### DIFF
--- a/image/redis/debian-13/8.8-compat.yaml
+++ b/image/redis/debian-13/8.8-compat.yaml
@@ -48,6 +48,7 @@ contents:
     - libpcre2-8-0
     - libssl3t64
     - libstdc++6
+    - libcrypt1
     - openssl
     - procps
     - sed


### PR DESCRIPTION
## Summary

Fixes #404

`redisearch.so` in Redis 8.8.0 has a new dependency on `libcrypt.so.1` (provided by `libcrypt1`) that was not present in earlier versions. The library was absent from the `8.8-compat` runtime image, causing Redis to abort on startup whenever a Stack module was loaded:

```
Module /usr/local/lib/redis/modules/redisearch.so failed to load: libcrypt.so.1: cannot open shared object file: No such file or directory
Can't load module from /usr/local/lib/redis/modules/redisearch.so: server aborting
```

The fix adds `libcrypt1` to the runtime `contents.packages` list alongside the existing `libssl3t64` and `libstdc++6` entries.

## Verification

**Reproduced on official image** — `libcrypt.so.1` absent, module load aborts with the error above.

**Built fixed image from yaml and confirmed all four Stack modules load:**

```
$ docker run --rm test-redis:8.8-compat \
    redis-server --loadmodule /usr/local/lib/redis/modules/redisearch.so --loglevel verbose
* Module 'search' loaded from /usr/local/lib/redis/modules/redisearch.so
* Ready to accept connections tcp

$ docker run --rm test-redis:8.8-compat \
    redis-server --loadmodule /usr/local/lib/redis/modules/redisbloom.so --loglevel verbose
* Module 'bf' loaded from /usr/local/lib/redis/modules/redisbloom.so
* Ready to accept connections tcp

$ docker run --rm test-redis:8.8-compat \
    redis-server --loadmodule /usr/local/lib/redis/modules/redistimeseries.so --loglevel verbose
* Module 'timeseries' loaded from /usr/local/lib/redis/modules/redistimeseries.so
* Ready to accept connections tcp

$ docker run --rm test-redis:8.8-compat \
    redis-server --loadmodule /usr/local/lib/redis/modules/rejson.so --loglevel verbose
* Module 'ReJSON' loaded from /usr/local/lib/redis/modules/rejson.so
* Ready to accept connections tcp
```