### PR TITLE
mongodb: add linux/arm64 platform support to debian-13 images

### DIFF
--- a/image/mongodb/debian-13/8.0-dev.yaml
+++ b/image/mongodb/debian-13/8.0-dev.yaml
@@ -12,6 +12,7 @@ tags:
   - 8.0.23-debian13-dev
 platforms:
   - linux/amd64
+  - linux/arm64
 dates:
   release: "2024-10-31"
   end-of-life: "2029-10-31"
@@ -21,6 +22,7 @@ vars:
   MONGO_TOOLS_COMMIT_SHA: 0b142f65e139525881b6a343bc56d8d98e5a1f90
   MONGO_TOOLS_VERSION: 100.17.0
   MONGODB_ARCH: '#{ target.arch == "amd64" ? "x86_64" : "aarch64" }'
+  MONGODB_DISTRO: '#{ target.arch == "amd64" ? "debian12" : "ubuntu2404" }'
   MONGOSH_ARCH: '#{ target.arch == "amd64" ? "x64" : "arm64" }'
   MONGOSH_VERSION: 2.8.3
   SEMVER_MAJOR_MINOR_VERSION: "8.0"
@@ -70,11 +72,11 @@ contents:
             path: ${source.dir}/keys/mongodb-server.asc
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.0.23.tgz
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.0.23.tgz
             path: ${source.dir}/mongodb-server-and-mongos.tgz
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.0.23.tgz.sig
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.0.23.tgz.sig
             path: ${source.dir}/mongodb-server-and-mongos.tgz.sig
             uid: 0
             gid: 0
@@ -94,7 +96,7 @@ contents:
 
             # Install only mongod for the base server
             mkdir -p "${target.dir}/usr/bin"
-            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-debian12-8.0.23/bin/mongod" "${target.dir}/usr/bin/mongod"
+            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.0.23/bin/mongod" "${target.dir}/usr/bin/mongod"
         - name: setup directories
           runs: |
             set -eux -o pipefail

--- a/image/mongodb/debian-13/8.0-dev.yaml
+++ b/image/mongodb/debian-13/8.0-dev.yaml
@@ -12,6 +12,7 @@ tags:
   - 8.0.29-debian13-dev
 platforms:
   - linux/amd64
+  - linux/arm64
 dates:
   release: "2024-10-31"
   end-of-life: "2029-10-31"
@@ -20,6 +21,10 @@ vars:
   MONGO_TOOLS_COMMIT_SHA: 21a342dfee6468ad9350d156d25086da64dd03b1
   MONGO_TOOLS_VERSION: 100.18.0
   MONGODB_ARCH: '#{ target.arch == "amd64" ? "x86_64" : "aarch64" }'
+  # MongoDB ships no aarch64 Debian binaries and declined to add them
+  # (SERVER-54692, Won't Fix), so arm64 uses the Ubuntu 24.04 build. It
+  # needs GLIBC_2.38; Debian 13 provides 2.41.
+  MONGODB_DISTRO: '#{ target.arch == "amd64" ? "debian12" : "ubuntu2404" }'
   MONGOSH_ARCH: '#{ target.arch == "amd64" ? "x64" : "arm64" }'
   MONGOSH_VERSION: 2.10.0
   SEMVER_MAJOR_MINOR_VERSION: "8.0"
@@ -73,11 +78,11 @@ contents:
             path: ${source.dir}/keys/mongodb-server.asc
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.0.29.tgz
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.0.29.tgz
             path: ${source.dir}/mongodb-server-and-mongos.tgz
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.0.29.tgz.sig
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.0.29.tgz.sig
             path: ${source.dir}/mongodb-server-and-mongos.tgz.sig
             uid: 0
             gid: 0
@@ -97,7 +102,7 @@ contents:
 
             # Install only mongod for the base server
             mkdir -p "${target.dir}/usr/bin"
-            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-debian12-8.0.29/bin/mongod" "${target.dir}/usr/bin/mongod"
+            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.0.29/bin/mongod" "${target.dir}/usr/bin/mongod"
         - name: setup directories
           runs: |
             set -eux -o pipefail

--- a/image/mongodb/debian-13/8.0.yaml
+++ b/image/mongodb/debian-13/8.0.yaml
@@ -12,6 +12,7 @@ tags:
   - 8.0.23-debian13
 platforms:
   - linux/amd64
+  - linux/arm64
 dates:
   release: "2024-10-31"
   end-of-life: "2029-10-31"
@@ -21,6 +22,7 @@ vars:
   MONGO_TOOLS_COMMIT_SHA: 0b142f65e139525881b6a343bc56d8d98e5a1f90
   MONGO_TOOLS_VERSION: 100.17.0
   MONGODB_ARCH: '#{ target.arch == "amd64" ? "x86_64" : "aarch64" }'
+  MONGODB_DISTRO: '#{ target.arch == "amd64" ? "debian12" : "ubuntu2404" }'
   MONGOSH_ARCH: '#{ target.arch == "amd64" ? "x64" : "arm64" }'
   MONGOSH_VERSION: 2.8.3
   SEMVER_MAJOR_MINOR_VERSION: "8.0"
@@ -58,11 +60,11 @@ contents:
             path: ${source.dir}/keys/mongodb-server.asc
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.0.23.tgz
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.0.23.tgz
             path: ${source.dir}/mongodb-server-and-mongos.tgz
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.0.23.tgz.sig
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.0.23.tgz.sig
             path: ${source.dir}/mongodb-server-and-mongos.tgz.sig
             uid: 0
             gid: 0
@@ -82,7 +84,7 @@ contents:
 
             # Install only mongod for the base server
             mkdir -p "${target.dir}/usr/bin"
-            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-debian12-8.0.23/bin/mongod" "${target.dir}/usr/bin/mongod"
+            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.0.23/bin/mongod" "${target.dir}/usr/bin/mongod"
         - name: setup directories
           runs: |
             set -eux -o pipefail

--- a/image/mongodb/debian-13/8.0.yaml
+++ b/image/mongodb/debian-13/8.0.yaml
@@ -12,6 +12,7 @@ tags:
   - 8.0.29-debian13
 platforms:
   - linux/amd64
+  - linux/arm64
 dates:
   release: "2024-10-31"
   end-of-life: "2029-10-31"
@@ -20,6 +21,10 @@ vars:
   MONGO_TOOLS_COMMIT_SHA: 21a342dfee6468ad9350d156d25086da64dd03b1
   MONGO_TOOLS_VERSION: 100.18.0
   MONGODB_ARCH: '#{ target.arch == "amd64" ? "x86_64" : "aarch64" }'
+  # MongoDB ships no aarch64 Debian binaries and declined to add them
+  # (SERVER-54692, Won't Fix), so arm64 uses the Ubuntu 24.04 build. It
+  # needs GLIBC_2.38; Debian 13 provides 2.41.
+  MONGODB_DISTRO: '#{ target.arch == "amd64" ? "debian12" : "ubuntu2404" }'
   MONGOSH_ARCH: '#{ target.arch == "amd64" ? "x64" : "arm64" }'
   MONGOSH_VERSION: 2.10.0
   SEMVER_MAJOR_MINOR_VERSION: "8.0"
@@ -61,11 +66,11 @@ contents:
             path: ${source.dir}/keys/mongodb-server.asc
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.0.29.tgz
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.0.29.tgz
             path: ${source.dir}/mongodb-server-and-mongos.tgz
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.0.29.tgz.sig
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.0.29.tgz.sig
             path: ${source.dir}/mongodb-server-and-mongos.tgz.sig
             uid: 0
             gid: 0
@@ -85,7 +90,7 @@ contents:
 
             # Install only mongod for the base server
             mkdir -p "${target.dir}/usr/bin"
-            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-debian12-8.0.29/bin/mongod" "${target.dir}/usr/bin/mongod"
+            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.0.29/bin/mongod" "${target.dir}/usr/bin/mongod"
         - name: setup directories
           runs: |
             set -eux -o pipefail

--- a/image/mongodb/debian-13/8.3-compat.yaml
+++ b/image/mongodb/debian-13/8.3-compat.yaml
@@ -16,6 +16,7 @@ tags:
   - 8.3.2-debian13-compat
 platforms:
   - linux/amd64
+  - linux/arm64
 dates:
   release: "2026-05-04"
   end-of-life: "2029-10-31"
@@ -25,6 +26,7 @@ vars:
   MONGO_TOOLS_COMMIT_SHA: 0b142f65e139525881b6a343bc56d8d98e5a1f90
   MONGO_TOOLS_VERSION: 100.17.0
   MONGODB_ARCH: '#{ target.arch == "amd64" ? "x86_64" : "aarch64" }'
+  MONGODB_DISTRO: '#{ target.arch == "amd64" ? "debian12" : "ubuntu2404" }'
   MONGOSH_ARCH: '#{ target.arch == "amd64" ? "x64" : "arm64" }'
   MONGOSH_VERSION: 2.8.3
   SEMVER_MAJOR_MINOR_VERSION: "8.3"
@@ -64,11 +66,11 @@ contents:
             path: ${source.dir}/keys/mongodb-server.asc
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.3.2.tgz
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.3.2.tgz
             path: ${source.dir}/mongodb-server-and-mongos.tgz
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.3.2.tgz.sig
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.3.2.tgz.sig
             path: ${source.dir}/mongodb-server-and-mongos.tgz.sig
             uid: 0
             gid: 0
@@ -88,7 +90,7 @@ contents:
 
             # Install only mongod for the base server
             mkdir -p "${target.dir}/usr/bin"
-            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-debian12-8.3.2/bin/mongod" "${target.dir}/usr/bin/mongod"
+            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.3.2/bin/mongod" "${target.dir}/usr/bin/mongod"
         - name: setup directories
           runs: |
             set -eux -o pipefail

--- a/image/mongodb/debian-13/8.3-compat.yaml
+++ b/image/mongodb/debian-13/8.3-compat.yaml
@@ -16,6 +16,7 @@ tags:
   - 8.3.8-debian13-compat
 platforms:
   - linux/amd64
+  - linux/arm64
 dates:
   release: "2026-05-04"
   end-of-life: "2029-10-31"
@@ -24,6 +25,10 @@ vars:
   MONGO_TOOLS_COMMIT_SHA: 21a342dfee6468ad9350d156d25086da64dd03b1
   MONGO_TOOLS_VERSION: 100.18.0
   MONGODB_ARCH: '#{ target.arch == "amd64" ? "x86_64" : "aarch64" }'
+  # MongoDB ships no aarch64 Debian binaries and declined to add them
+  # (SERVER-54692, Won't Fix), so arm64 uses the Ubuntu 24.04 build. It
+  # needs GLIBC_2.38; Debian 13 provides 2.41.
+  MONGODB_DISTRO: '#{ target.arch == "amd64" ? "debian12" : "ubuntu2404" }'
   MONGOSH_ARCH: '#{ target.arch == "amd64" ? "x64" : "arm64" }'
   MONGOSH_VERSION: 2.10.0
   SEMVER_MAJOR_MINOR_VERSION: "8.3"
@@ -67,11 +72,11 @@ contents:
             path: ${source.dir}/keys/mongodb-server.asc
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.3.8.tgz
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.3.8.tgz
             path: ${source.dir}/mongodb-server-and-mongos.tgz
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.3.8.tgz.sig
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.3.8.tgz.sig
             path: ${source.dir}/mongodb-server-and-mongos.tgz.sig
             uid: 0
             gid: 0
@@ -91,7 +96,7 @@ contents:
 
             # Install only mongod for the base server
             mkdir -p "${target.dir}/usr/bin"
-            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-debian12-8.3.8/bin/mongod" "${target.dir}/usr/bin/mongod"
+            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.3.8/bin/mongod" "${target.dir}/usr/bin/mongod"
         - name: setup directories
           runs: |
             set -eux -o pipefail

--- a/image/mongodb/debian-13/8.3-dev.yaml
+++ b/image/mongodb/debian-13/8.3-dev.yaml
@@ -15,6 +15,7 @@ tags:
   - 8.3.2-debian13-dev
 platforms:
   - linux/amd64
+  - linux/arm64
 dates:
   release: "2026-05-04"
   end-of-life: "2029-10-31"
@@ -24,6 +25,7 @@ vars:
   MONGO_TOOLS_COMMIT_SHA: 0b142f65e139525881b6a343bc56d8d98e5a1f90
   MONGO_TOOLS_VERSION: 100.17.0
   MONGODB_ARCH: '#{ target.arch == "amd64" ? "x86_64" : "aarch64" }'
+  MONGODB_DISTRO: '#{ target.arch == "amd64" ? "debian12" : "ubuntu2404" }'
   MONGOSH_ARCH: '#{ target.arch == "amd64" ? "x64" : "arm64" }'
   MONGOSH_VERSION: 2.8.3
   SEMVER_MAJOR_MINOR_VERSION: "8.3"
@@ -73,11 +75,11 @@ contents:
             path: ${source.dir}/keys/mongodb-server.asc
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.3.2.tgz
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.3.2.tgz
             path: ${source.dir}/mongodb-server-and-mongos.tgz
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.3.2.tgz.sig
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.3.2.tgz.sig
             path: ${source.dir}/mongodb-server-and-mongos.tgz.sig
             uid: 0
             gid: 0
@@ -97,7 +99,7 @@ contents:
 
             # Install only mongod for the base server
             mkdir -p "${target.dir}/usr/bin"
-            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-debian12-8.3.2/bin/mongod" "${target.dir}/usr/bin/mongod"
+            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.3.2/bin/mongod" "${target.dir}/usr/bin/mongod"
         - name: setup directories
           runs: |
             set -eux -o pipefail

--- a/image/mongodb/debian-13/8.3-dev.yaml
+++ b/image/mongodb/debian-13/8.3-dev.yaml
@@ -15,6 +15,7 @@ tags:
   - 8.3.8-debian13-dev
 platforms:
   - linux/amd64
+  - linux/arm64
 dates:
   release: "2026-05-04"
   end-of-life: "2029-10-31"
@@ -23,6 +24,10 @@ vars:
   MONGO_TOOLS_COMMIT_SHA: 21a342dfee6468ad9350d156d25086da64dd03b1
   MONGO_TOOLS_VERSION: 100.18.0
   MONGODB_ARCH: '#{ target.arch == "amd64" ? "x86_64" : "aarch64" }'
+  # MongoDB ships no aarch64 Debian binaries and declined to add them
+  # (SERVER-54692, Won't Fix), so arm64 uses the Ubuntu 24.04 build. It
+  # needs GLIBC_2.38; Debian 13 provides 2.41.
+  MONGODB_DISTRO: '#{ target.arch == "amd64" ? "debian12" : "ubuntu2404" }'
   MONGOSH_ARCH: '#{ target.arch == "amd64" ? "x64" : "arm64" }'
   MONGOSH_VERSION: 2.10.0
   SEMVER_MAJOR_MINOR_VERSION: "8.3"
@@ -76,11 +81,11 @@ contents:
             path: ${source.dir}/keys/mongodb-server.asc
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.3.8.tgz
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.3.8.tgz
             path: ${source.dir}/mongodb-server-and-mongos.tgz
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.3.8.tgz.sig
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.3.8.tgz.sig
             path: ${source.dir}/mongodb-server-and-mongos.tgz.sig
             uid: 0
             gid: 0
@@ -100,7 +105,7 @@ contents:
 
             # Install only mongod for the base server
             mkdir -p "${target.dir}/usr/bin"
-            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-debian12-8.3.8/bin/mongod" "${target.dir}/usr/bin/mongod"
+            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.3.8/bin/mongod" "${target.dir}/usr/bin/mongod"
         - name: setup directories
           runs: |
             set -eux -o pipefail

--- a/image/mongodb/debian-13/8.3.yaml
+++ b/image/mongodb/debian-13/8.3.yaml
@@ -15,6 +15,7 @@ tags:
   - 8.3.2-debian13
 platforms:
   - linux/amd64
+  - linux/arm64
 dates:
   release: "2026-05-04"
   end-of-life: "2029-10-31"
@@ -24,6 +25,7 @@ vars:
   MONGO_TOOLS_COMMIT_SHA: 0b142f65e139525881b6a343bc56d8d98e5a1f90
   MONGO_TOOLS_VERSION: 100.17.0
   MONGODB_ARCH: '#{ target.arch == "amd64" ? "x86_64" : "aarch64" }'
+  MONGODB_DISTRO: '#{ target.arch == "amd64" ? "debian12" : "ubuntu2404" }'
   MONGOSH_ARCH: '#{ target.arch == "amd64" ? "x64" : "arm64" }'
   MONGOSH_VERSION: 2.8.3
   SEMVER_MAJOR_MINOR_VERSION: "8.3"
@@ -61,11 +63,11 @@ contents:
             path: ${source.dir}/keys/mongodb-server.asc
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.3.2.tgz
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.3.2.tgz
             path: ${source.dir}/mongodb-server-and-mongos.tgz
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.3.2.tgz.sig
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.3.2.tgz.sig
             path: ${source.dir}/mongodb-server-and-mongos.tgz.sig
             uid: 0
             gid: 0
@@ -85,7 +87,7 @@ contents:
 
             # Install only mongod for the base server
             mkdir -p "${target.dir}/usr/bin"
-            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-debian12-8.3.2/bin/mongod" "${target.dir}/usr/bin/mongod"
+            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.3.2/bin/mongod" "${target.dir}/usr/bin/mongod"
         - name: setup directories
           runs: |
             set -eux -o pipefail

--- a/image/mongodb/debian-13/8.3.yaml
+++ b/image/mongodb/debian-13/8.3.yaml
@@ -15,6 +15,7 @@ tags:
   - 8.3.8-debian13
 platforms:
   - linux/amd64
+  - linux/arm64
 dates:
   release: "2026-05-04"
   end-of-life: "2029-10-31"
@@ -23,6 +24,10 @@ vars:
   MONGO_TOOLS_COMMIT_SHA: 21a342dfee6468ad9350d156d25086da64dd03b1
   MONGO_TOOLS_VERSION: 100.18.0
   MONGODB_ARCH: '#{ target.arch == "amd64" ? "x86_64" : "aarch64" }'
+  # MongoDB ships no aarch64 Debian binaries and declined to add them
+  # (SERVER-54692, Won't Fix), so arm64 uses the Ubuntu 24.04 build. It
+  # needs GLIBC_2.38; Debian 13 provides 2.41.
+  MONGODB_DISTRO: '#{ target.arch == "amd64" ? "debian12" : "ubuntu2404" }'
   MONGOSH_ARCH: '#{ target.arch == "amd64" ? "x64" : "arm64" }'
   MONGOSH_VERSION: 2.10.0
   SEMVER_MAJOR_MINOR_VERSION: "8.3"
@@ -64,11 +69,11 @@ contents:
             path: ${source.dir}/keys/mongodb-server.asc
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.3.8.tgz
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.3.8.tgz
             path: ${source.dir}/mongodb-server-and-mongos.tgz
             uid: 0
             gid: 0
-          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-debian12-8.3.8.tgz.sig
+          - url: https://fastdl.mongodb.org/linux/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.3.8.tgz.sig
             path: ${source.dir}/mongodb-server-and-mongos.tgz.sig
             uid: 0
             gid: 0
@@ -88,7 +93,7 @@ contents:
 
             # Install only mongod for the base server
             mkdir -p "${target.dir}/usr/bin"
-            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-debian12-8.3.8/bin/mongod" "${target.dir}/usr/bin/mongod"
+            cp "${source.dir}/mongodb-linux-${MONGODB_ARCH}-${MONGODB_DISTRO}-8.3.8/bin/mongod" "${target.dir}/usr/bin/mongod"
         - name: setup directories
           runs: |
             set -eux -o pipefail


### PR DESCRIPTION
## Summary

Fixes #159.

Adds `linux/arm64` to all five MongoDB debian-13 images (8.0, 8.0-dev, 8.3, 8.3-compat, 8.3-dev). `mongodb` is currently one of only 8 amd64-only images in the debian-13 catalog.

Most of the arch plumbing already exists — `MONGODB_ARCH` and `MONGOSH_ARCH` are both arch ternaries today. The only things pinning these images to amd64 are the `platforms:` list and the literal `debian12` in the mongod download URL.

## Why a per-arch distro

MongoDB has never published an aarch64 Debian build, in any release. `full.json` lists 11 aarch64 targets (ubuntu1804/2004/2204/2404, rhel8/82/90/93/10, amazon2/2023) and zero Debian ones. Debian ARM support was requested and declined upstream: SERVER-54692, closed Won't Fix.

So arm64 has to come from a different upstream build family. `MONGODB_DISTRO` selects `ubuntu2404` there and keeps `debian12` on amd64, so the existing amd64 image is unchanged.

This mirrors `litellm-database`, which selects `query-engine-debian-openssl-3.0.x` on amd64 and `query-engine-linux-arm64-openssl-3.0.x` on arm64 for the same reason.

**Alternative considered:** using `ubuntu2404` on both arches would be symmetric and would drop the ternary entirely, but it re-bases the amd64 image that everyone currently runs. I kept this additive — happy to switch if you'd prefer the symmetry.

## Why the Ubuntu build is safe on a Debian 13 runtime

Comparing MongoDB's own 8.3.8 binaries:

| build | max GLIBC symbol required | NEEDED |
|---|---|---|
| `x86_64-debian12` (ships today) | `GLIBC_2.36` | libcurl.so.4, libssl.so.3, libcrypto.so.3, libm, libresolv, libgcc_s, libc |
| `x86_64-ubuntu2404` | `GLIBC_2.38` | identical |
| `aarch64-ubuntu2404` (this PR) | `GLIBC_2.38` | identical |

Identical shared-library dependency set, and the two same-arch builds differ by 1,256 bytes. Debian 13 provides glibc 2.41, so 2.38 is satisfied with room to spare, and the image already pulls in the OpenSSL 3 sonames via `libcurl4t64`.

This is the same class of compatibility the image already relies on: it runs MongoDB's `debian12` binaries on a trixie runtime today, because no debian13 build exists for 8.x.

## Verification

Upstream artifacts present for every version this PR touches:

```
200  mongodb-linux-aarch64-ubuntu2404-8.0.29.tgz  (+ .sig)
200  mongodb-linux-aarch64-ubuntu2404-8.3.8.tgz   (+ .sig)
200  mongosh-2.10.0-linux-arm64-openssl3.tgz      (+ .sig)
```

mongo-tools is built from source with `CGO_ENABLED=0 go build`, so it is arch-agnostic.

Original reproduction and build, done at 8.3.2 when this PR was first opened:

```
$ docker pull --platform linux/arm64 dhi.io/mongodb:8.3.2-debian13
no matching manifest for linux/arm64 in the manifest list entries

# adding linux/arm64 alone fails — the CDN has no aarch64-debian12 build
download file https://fastdl.mongodb.org/linux/mongodb-linux-aarch64-debian12-8.3.2.tgz
ERROR: invalid response status 403

# with MONGODB_DISTRO
$ docker run --rm --platform linux/arm64 test-mongo:8.3-arm64 mongod --version
db version v8.3.2
Build Info: { ..., "distarch": "aarch64", "target_arch": "aarch64" }
```

Refreshed against current main (8.0.29 / 8.3.8 / mongosh 2.10.0 / mongo-tools 100.18.0).