### PR TITLE
logstash: add 9.4 compat version

### DIFF
--- a/image/logstash/debian-13/9.4-compat.yaml
+++ b/image/logstash/debian-13/9.4-compat.yaml
@@ -1,0 +1,702 @@
+# syntax=dhi.io/build:2-debian13
+
+name: Logstash 9.4.x (compat)
+image: dhi.io/logstash
+variant: runtime
+flavor: compat
+tags:
+  - 9-compat
+  - 9.4-compat
+  - 9.4.2-compat
+  - 9-debian-compat
+  - 9-debian13-compat
+  - 9.4-debian-compat
+  - 9.4-debian13-compat
+  - 9.4.2-debian-compat
+  - 9.4.2-debian13-compat
+platforms:
+  - linux/amd64
+  - linux/arm64
+dates:
+  release: "2026-04-28"
+vars:
+  ARCH: '#{ target.arch == "amd64" ? "x86_64" : "aarch64" }'
+  COMMIT_SHA: 4d51b94a54decd3cae250e66ea42db5e23f8a5b6
+  GOLANG_REFERENCE: dhi/golang:1.26.4-debian13-dev@sha256:9350c6e0c0a06f23b487c39850188b2a5c2bd176d1fc5ae361400c8c068e42b0
+  GRADLE_REFERENCE: dhi/gradle:8.14.5-jdk21-debian13-dev@sha256:698c405528f9396ec233daaef939e8a8a8e21254fc723deafe27fb4bae4f7b0e
+  GRADLE_VERSION: 8.14.5
+  JAVA_MAJOR_VERSION: "21"
+  JDK_REFERENCE: dhi/eclipse-temurin:21.0.11.10-jdk-debian13-dev@sha256:bbe0dfdd7ea19a8d0756efb3c1f96e2d7c70688776e49c0e96142820373027bc
+  JDK_VERSION: 21.0.11.10
+  LOGSTASH_JRUBY_BUNDLE_SEGMENT: 3.4.0
+  LOGSTASH_PATH: /usr/share/logstash
+  LOGSTASH_SOURCE: "1"
+  OSS: "true"
+  SEMVER_MAJOR_MINOR_VERSION: "9.4"
+  SEMVER_MAJOR_VERSION: "9"
+  SEMVER_VERSION: 9.4.2
+  VERSION: 9.4.2
+contents:
+  packages:
+    - '!libelogind0'
+    - '!mawk'
+    - '!original-awk'
+    - base-files
+    - bash
+    - coreutils
+    - openssl
+    - sed
+  builds:
+    - name: env2yaml java for 8.19+
+      uses: dhi.io/gradle:8.14.5-jdk21-debian13-dev@sha256:698c405528f9396ec233daaef939e8a8a8e21254fc723deafe27fb4bae4f7b0e
+      contents:
+        packages:
+          - bash
+          - coreutils
+        files:
+          - url: git+https://github.com/elastic/logstash.git#4d51b94a54decd3cae250e66ea42db5e23f8a5b6
+            checksum: 4d51b94a54decd3cae250e66ea42db5e23f8a5b6
+            path: ${source.dir}/logstash
+            uid: 0
+            gid: 0
+      pipeline:
+        - name: build env2yaml java
+          work-dir: ${source.dir}/logstash/docker/data/logstash/env2yaml
+          privileged: true
+          secrets:
+            - id: maven_user
+              env: MAVEN_USER
+            - id: maven_password
+              env: MAVEN_PASSWORD
+          runs: |
+            set -eux -o pipefail
+
+            gradle build
+      outputs:
+        - source: ${source.dir}/logstash/docker/data/logstash/env2yaml
+          target: /usr/share/logstash/env2yaml
+          uid: 0
+          gid: 0
+          mode: "0755"
+        - source: ${source.dir}/logstash/docker/data/logstash/env2yaml/env2yaml
+          target: /usr/local/bin/env2yaml
+          uid: 0
+          gid: 0
+          mode: "0755"
+    - name: build logstash
+      uses: dhi.io/gradle:8.14.5-jdk21-debian13-dev@sha256:698c405528f9396ec233daaef939e8a8a8e21254fc723deafe27fb4bae4f7b0e
+      contents:
+        packages:
+          - coreutils
+          - curl
+          - findutils
+          - grep
+          - gzip
+          - libc6-dev
+          - make
+          - sed
+          - tar
+        files:
+          - url: git+https://github.com/elastic/logstash.git#v9.4.2
+            checksum: 4d51b94a54decd3cae250e66ea42db5e23f8a5b6
+            path: ${source.dir}/logstash
+            spdx:
+              name: logstash
+              version: 9.4.2
+              packages:
+                - name: logstash
+                  purl: pkg:dhi/logstash@9.4.2
+                  license: Apache-2.0
+            uid: 0
+            gid: 0
+          - url: https://repo1.maven.org/maven2/at/yawk/lz4/lz4-java/1.10.1/lz4-java-1.10.1.jar
+            path: ${source.dir}/patch/deps/lz4-java-1.10.1.jar
+            uid: 0
+            gid: 0
+          - url: https://repo1.maven.org/maven2/com/fasterxml/jackson/core/jackson-core/2.18.6/jackson-core-2.18.6.jar
+            path: ${source.dir}/patch/deps/jackson-core-2.18.6.jar
+            uid: 0
+            gid: 0
+          - url: https://repo1.maven.org/maven2/org/apache/kafka/kafka-clients/3.9.2/kafka-clients-3.9.2.jar
+            path: ${source.dir}/patch/deps/kafka-clients-3.9.2.jar
+            uid: 0
+            gid: 0
+          - url: https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-1.2-api/2.25.4/log4j-1.2-api-2.25.4.jar
+            path: ${source.dir}/patch/deps/log4j-1.2-api-2.25.4.jar
+            uid: 0
+            gid: 0
+          - url: https://repo1.maven.org/maven2/io/netty/netty-codec/4.1.133.Final/netty-codec-4.1.133.Final.jar
+            checksum: sha256:65d9fd0b5ae80ddda532b3a98bf5adbd4f34ec6ae19ba2439eab2ed3d6d79c5a
+            path: ${source.dir}/patch/deps/netty-codec-4.1.133.Final.jar
+            uid: 0
+            gid: 0
+          - url: https://repo1.maven.org/maven2/io/netty/netty-codec-http/4.1.133.Final/netty-codec-http-4.1.133.Final.jar
+            checksum: sha256:cb82f9fd12d9cd3c3bf2306080e2230a29fcddaab388fc8a36bd7b2c7e1e49ec
+            path: ${source.dir}/patch/deps/netty-codec-http-4.1.133.Final.jar
+            uid: 0
+            gid: 0
+          - url: https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk18on/1.84/bcprov-jdk18on-1.84.jar
+            checksum: sha256:64d6c5a6121fcd927152dd182cbed39afe0fda641a970d9bcc0c9cb1858b2731
+            path: ${source.dir}/patch/deps/bcprov-jdk18on-1.84.jar
+            uid: 0
+            gid: 0
+          - url: https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-jdk18on/1.84/bcpkix-jdk18on-1.84.jar
+            checksum: sha256:c87f16ed9e5ec61bc94151e9f3646ac44e50cd448121ce84367fa4b7ec7ec1bb
+            path: ${source.dir}/patch/deps/bcpkix-jdk18on-1.84.jar
+            uid: 0
+            gid: 0
+          - url: https://repo1.maven.org/maven2/org/bouncycastle/bcutil-jdk18on/1.84/bcutil-jdk18on-1.84.jar
+            checksum: sha256:b374e16963421fb9cfb01cc20d7ad8fd2f8b8188e3eef0ec0a8965e245f7619a
+            path: ${source.dir}/patch/deps/bcutil-jdk18on-1.84.jar
+            uid: 0
+            gid: 0
+          - url: https://repo1.maven.org/maven2/org/bouncycastle/bctls-jdk18on/1.84/bctls-jdk18on-1.84.jar
+            checksum: sha256:a0591da70ced0f637f1b7e2df431dd91c3cb7c8511e6f75267e7850b2e293ccc
+            path: ${source.dir}/patch/deps/bctls-jdk18on-1.84.jar
+            uid: 0
+            gid: 0
+          - url: https://repo1.maven.org/maven2/tools/jackson/core/jackson-core/3.1.1/jackson-core-3.1.1.jar
+            checksum: sha256:4cd270bee1a1aa34be18da78268f3879355b6ea09154beff496831785b6194c9
+            path: ${source.dir}/patch/deps/tools-jackson-core-3.1.1.jar
+            uid: 0
+            gid: 0
+          - url: https://rubygems.org/downloads/cgi-0.3.7.gem
+            checksum: sha256:0a18f23f329725de2f9ce601c82765585cc81fad92f30d70c9e672c7dbc451bd
+            path: ${source.dir}/patch/deps/cgi-0.3.7.gem
+            uid: 0
+            gid: 0
+          - url: https://rubygems.org/downloads/erb-4.0.3.1.gem
+            checksum: sha256:bcaaef8cbaa9c46674487c95636050820262ba61293cf33f10242a90dc80654f
+            path: ${source.dir}/patch/deps/erb-4.0.3.1.gem
+            uid: 0
+            gid: 0
+          - url: https://rubygems.org/downloads/net-imap-0.5.14.gem
+            checksum: sha256:1590ca018d65d4165b7324a3f046dd16fd9dd5e72deba4acf494c1becdb55a04
+            path: ${source.dir}/patch/deps/net-imap-0.5.14.gem
+            uid: 0
+            gid: 0
+          - url: https://rubygems.org/downloads/net-imap-0.6.4.gem
+            checksum: sha256:9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
+            path: ${source.dir}/patch/deps/net-imap-0.6.4.gem
+            uid: 0
+            gid: 0
+          - url: https://rubygems.org/downloads/nokogiri-1.19.3-java.gem
+            checksum: sha256:40ea6ebf5cf2005dae1dee26dd557d3afb41fb6de6c9764aca8cf06fdb841db1
+            path: ${source.dir}/patch/deps/nokogiri-1.19.3-java.gem
+            uid: 0
+            gid: 0
+          - url: https://rubygems.org/downloads/rexml-3.4.4.gem
+            checksum: sha256:19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
+            path: ${source.dir}/patch/deps/rexml-3.4.4.gem
+            uid: 0
+            gid: 0
+          - url: https://rubygems.org/downloads/uri-0.12.5.gem
+            checksum: sha256:883424e272244f029ad3b9fe0e9ad18d1c33cdadff0a366c301ce737c62eb414
+            path: ${source.dir}/patch/deps/uri-0.12.5.gem
+            uid: 0
+            gid: 0
+      pipeline:
+        - name: patch deps
+          uses: git/patch@v1
+          work-dir: ${source.dir}/logstash
+          with:
+            patch: ${source.dir}/patch/deps-9.4.patch
+        - name: install default gems
+          work-dir: ${source.dir}/logstash
+          privileged: true
+          secrets:
+            - id: maven_user
+              env: MAVEN_USER
+            - id: maven_password
+              env: MAVEN_PASSWORD
+          runs: |
+            set -eux -o pipefail
+
+            gradle installDefaultGems
+        - name: install assemble tar distro
+          work-dir: ${source.dir}/logstash
+          privileged: true
+          secrets:
+            - id: maven_user
+              env: MAVEN_USER
+            - id: maven_password
+              env: MAVEN_PASSWORD
+          runs: |
+            set -eux -o pipefail
+
+            gradle assembleTarDistribution
+        - name: unpack
+          work-dir: ${source.dir}/logstash
+          runs: |
+            set -eux -o pipefail
+
+            tar -zxf "build/logstash-9.4.2-SNAPSHOT.tar.gz" -C /usr/share
+
+            mkdir -p "${target.dir}/usr/share/logstash"
+
+            # Remove bundled JDK - we use DHI Java JDK instead
+            rm -rf "/usr/share/logstash-9.4.2"-SNAPSHOT/jdk
+
+            cp -r "/usr/share/logstash-9.4.2"-SNAPSHOT/* "${target.dir}/usr/share/logstash"
+        - name: replace vulnerable kafka-clients jar
+          work-dir: ${source.dir}/logstash
+          runs: |
+            set -eux -o pipefail
+
+            # CVE-2026-35554 - Ensure kafka-clients is at least 3.9.2 inside logstash-integration-kafka.
+            # Newer gems may omit the maven-style .../org/apache/kafka/kafka-clients directory; locate jars directly.
+            base="${target.dir}/usr/share/logstash/vendor/bundle/jruby/3.4.0/gems"
+            kafka_fixed="${source.dir}/patch/deps/kafka-clients-3.9.2.jar"
+
+            kafka_old_count=$(find "$base" -type f -name 'kafka-clients-*.jar' ! -name 'kafka-clients-3.9.2.jar' | wc -l | tr -d ' ')
+
+            if [ "${kafka_old_count:-0}" -eq 0 ]; then
+              echo "No kafka-clients JAR older than 3.9.2 found; skipping CVE-2026-35554 shim."
+              exit 0
+            fi
+
+            for old_kafka_jar in $(find "$base" -type f -name 'kafka-clients-*.jar' ! -name 'kafka-clients-3.9.2.jar'); do
+              version_dir=$(dirname "$old_kafka_jar")
+              clients_root=$(dirname "$version_dir")
+
+              if [ "$(basename "$clients_root")" = "kafka-clients" ]; then
+                rm "$old_kafka_jar"
+                rmdir "$version_dir" 2> /dev/null || true
+                mkdir -p "$clients_root/3.9.2"
+                cp "$kafka_fixed" "$clients_root/3.9.2/kafka-clients-3.9.2.jar"
+              else
+                echo "kafka-clients CVE shim: non-maven layout; replacing $old_kafka_jar"
+                jar_dir=$(dirname "$old_kafka_jar")
+                rm "$old_kafka_jar"
+                cp "$kafka_fixed" "$jar_dir/kafka-clients-3.9.2.jar"
+              fi
+            done
+
+            kafka_remain=$(find "$base" -type f -name 'kafka-clients-*.jar' ! -name 'kafka-clients-3.9.2.jar' | wc -l | tr -d ' ')
+            if [ "${kafka_remain:-0}" -gt 0 ]; then
+              echo "ERROR: kafka-clients CVE shim left ${kafka_remain} vulnerable jar(s)"
+              exit 1
+            fi
+        - name: replace vulnerable maven jars
+          work-dir: ${source.dir}/logstash
+          runs: |
+            set -eux -o pipefail
+
+            base="${target.dir}/usr/share/logstash"
+
+            replace_jars() {
+              pattern="$1"
+              fixed="$2"
+              find "$base" -path "$pattern" -type f | while read -r old_jar; do
+                echo "Replacing $old_jar with $fixed"
+                cp "$fixed" "$old_jar"
+              done
+            }
+
+            replace_jars "*/io/netty/netty-codec/*/netty-codec-*.jar" "${source.dir}/patch/deps/netty-codec-4.1.133.Final.jar"
+            replace_jars "*/io/netty/netty-codec-http/*/netty-codec-http-*.jar" "${source.dir}/patch/deps/netty-codec-http-4.1.133.Final.jar"
+            replace_jars "*/org/bouncycastle/bcprov-jdk18on/*/bcprov-jdk18on-*.jar" "${source.dir}/patch/deps/bcprov-jdk18on-1.84.jar"
+            replace_jars "*/org/bouncycastle/bcpkix-jdk18on/*/bcpkix-jdk18on-*.jar" "${source.dir}/patch/deps/bcpkix-jdk18on-1.84.jar"
+            replace_jars "*/tools/jackson/core/jackson-core/*/jackson-core-*.jar" "${source.dir}/patch/deps/tools-jackson-core-3.1.1.jar"
+        - name: replace vulnerable jackson-core jars
+          work-dir: ${source.dir}/logstash
+          runs: |
+            set -eux -o pipefail
+
+            # GHSA-72hv-8253-57qq - Replace all vulnerable jackson-core JARs with fixed version 2.18.6
+            # We replace the JAR contents in-place to preserve the directory structure that
+            # gems like jrjackson expect (they have hardcoded paths in their Ruby loader files)
+            base="${target.dir}/usr/share/logstash/vendor/bundle/jruby/3.4.0/gems"
+            jackson_fixed="${source.dir}/patch/deps/jackson-core-2.18.6.jar"
+
+            # Find and replace all jackson-core JARs in the gems directory in-place
+            # This handles all versions (jrjackson, kafka, azure, geoip, etc.)
+            find "$base" -path "*/jackson-core/*/jackson-core-*.jar" -type f | while read -r old_jar; do
+              echo "Replacing $old_jar with fixed version"
+              cp "$jackson_fixed" "$old_jar"
+            done
+
+            # Also replace jackson-core in logstash-core/lib/jars if it exists (8.19+)
+            core_jar=$(find "${target.dir}/usr/share/logstash/logstash-core/lib/jars" -name "jackson-core-*.jar" -type f 2> /dev/null | head -1)
+            if [ -n "$core_jar" ] && [ -f "$core_jar" ]; then
+              echo "Replacing $core_jar with fixed version"
+              cp "$jackson_fixed" "$core_jar"
+            fi
+        - name: patch shaded jackson-core in elastic_integration jar
+          work-dir: ${source.dir}/logstash
+          runs: |
+            set -eux -o pipefail
+
+            # The logstash-filter-elastic_integration JAR is a shaded/uber JAR that contains
+            # jackson-core classes embedded directly inside it. We need to replace these.
+            # GHSA-72hv-8253-57qq
+
+            JAR_CMD="/opt/java/openjdk/21/bin/jar"
+            jackson_fixed="${source.dir}/patch/deps/jackson-core-2.18.6.jar"
+            base="${target.dir}/usr/share/logstash/vendor/bundle/jruby/3.4.0/gems"
+
+            # Find the elastic_integration shaded JAR (version varies by logstash version)
+            ei_jar=$(find "$base" -path "*/logstash-filter-elastic_integration-*/vendor/jar-dependencies/co/elastic/logstash-filter-elastic_integration/*/logstash-filter-elastic_integration-*.jar" -type f | head -1)
+
+            if [ -z "$ei_jar" ]; then
+              echo "WARNING: No elastic_integration JAR found, skipping"
+              exit 0
+            fi
+
+            echo "Patching shaded JAR: $ei_jar"
+            work_dir="/tmp/ei_jar_patch"
+
+            mkdir -p "$work_dir"
+            cd "$work_dir"
+
+            # Extract the shaded JAR
+            "$JAR_CMD" xf "$ei_jar"
+
+            # Remove the old embedded jackson-core classes at root level
+            rm -rf com/fasterxml/jackson/core
+
+            # Extract the fixed jackson-core classes into the same location
+            "$JAR_CMD" xf "$jackson_fixed" 'com/fasterxml/jackson/core'
+
+            # Also update the pom metadata to reflect the new version
+            "$JAR_CMD" xf "$jackson_fixed" 'META-INF/maven/com.fasterxml.jackson.core/jackson-core'
+
+            # Replace the nested JAR in IMPL-JARS/x-content with fixed version
+            # Update both the directory name AND LISTING.TXT to avoid any reference to vulnerable version
+            if [ -d "IMPL-JARS/x-content" ]; then
+              # Find the old jackson-core directory name (e.g., jackson-core-2.17.2.jar)
+              old_jackson_name=$(find IMPL-JARS/x-content -maxdepth 1 -type d -name "jackson-core-*.jar" -printf "%f\n" | head -1)
+
+              if [ -z "$old_jackson_name" ]; then
+                echo "WARNING: No existing jackson-core JAR found in IMPL-JARS/x-content, skipping"
+              else
+                echo "Replacing $old_jackson_name with jackson-core-2.18.6.jar"
+
+                # Remove old version directory completely
+                rm -rf "IMPL-JARS/x-content/$old_jackson_name"
+
+                # Create new version directory with fixed version name
+                mkdir -p "IMPL-JARS/x-content/jackson-core-2.18.6.jar"
+                cd "IMPL-JARS/x-content/jackson-core-2.18.6.jar"
+
+                # Extract fixed JAR contents
+                "$JAR_CMD" xf "$jackson_fixed"
+
+                cd "$work_dir"
+
+                # Update LISTING.TXT to reflect the new JAR name
+                if [ -f "IMPL-JARS/x-content/LISTING.TXT" ]; then
+                  sed -i "s|$old_jackson_name|jackson-core-2.18.6.jar|g" IMPL-JARS/x-content/LISTING.TXT
+                  echo "Updated LISTING.TXT: $old_jackson_name -> jackson-core-2.18.6.jar"
+                else
+                  echo "WARNING: LISTING.TXT not found in IMPL-JARS/x-content"
+                fi
+              fi
+            fi
+
+            # Repack the JAR (preserving manifest and other metadata)
+            rm "$ei_jar"
+            "$JAR_CMD" cf "$ei_jar" .
+
+            # Cleanup
+            cd /
+            rm -rf "$work_dir"
+
+            # Verify the fix was applied
+            "$JAR_CMD" tf "$ei_jar" | grep -q "com/fasterxml/jackson/core/JsonFactory.class"
+        - name: patch shaded log4j-1.2-api in elastic_integration jar
+          work-dir: ${source.dir}/logstash
+          runs: |
+            set -eux -o pipefail
+
+            # CVE-2026-34479 - The logstash-filter-elastic_integration shaded JAR embeds
+            # log4j-1.2-api 2.19.0 classes from the bundled Elasticsearch distribution.
+            # Replace them with the fixed version 2.25.4.
+
+            JAR_CMD="/opt/java/openjdk/21/bin/jar"
+            log4j_fixed="${source.dir}/patch/deps/log4j-1.2-api-2.25.4.jar"
+            base="${target.dir}/usr/share/logstash/vendor/bundle/jruby/3.4.0/gems"
+
+            ei_jar=$(find "$base" -path "*/logstash-filter-elastic_integration-*/vendor/jar-dependencies/co/elastic/logstash-filter-elastic_integration/*/logstash-filter-elastic_integration-*.jar" -type f | head -1)
+
+            if [ -z "$ei_jar" ]; then
+              echo "WARNING: No elastic_integration JAR found, skipping"
+              exit 0
+            fi
+
+            echo "Patching log4j-1.2-api in shaded JAR: $ei_jar"
+            work_dir="/tmp/ei_jar_log4j_patch"
+
+            mkdir -p "$work_dir"
+            cd "$work_dir"
+
+            # Extract the shaded JAR
+            "$JAR_CMD" xf "$ei_jar"
+
+            # Remove the old embedded log4j-1.2-api classes
+            rm -rf org/apache/log4j
+
+            # Extract the fixed log4j-1.2-api classes into the same location
+            "$JAR_CMD" xf "$log4j_fixed" 'org/apache/log4j'
+
+            # Update the pom metadata to reflect the new version
+            rm -rf META-INF/maven/org.apache.logging.log4j/log4j-1.2-api
+            "$JAR_CMD" xf "$log4j_fixed" 'META-INF/maven/org.apache.logging.log4j/log4j-1.2-api'
+
+            # Repack the JAR
+            rm "$ei_jar"
+            "$JAR_CMD" cf "$ei_jar" .
+
+            # Cleanup
+            cd /
+            rm -rf "$work_dir"
+
+            # Verify the fix was applied
+            "$JAR_CMD" tf "$ei_jar" | grep -q "org/apache/log4j/Category.class"
+        - name: fix vulnerable ruby gems
+          work-dir: ${source.dir}/logstash
+          runs: |
+            set -eux -o pipefail
+
+            bundle_dir="${target.dir}/usr/share/logstash/vendor/bundle/jruby/3.4.0"
+            jruby_bin="${target.dir}/usr/share/logstash/vendor/jruby/bin"
+            jruby_stdlib="${target.dir}/usr/share/logstash/vendor/jruby/lib/ruby/stdlib"
+            shared_spec_dir="${target.dir}/usr/share/logstash/vendor/jruby/lib/ruby/gems/shared/specifications"
+            default_spec_dir="${target.dir}/usr/share/logstash/vendor/jruby/lib/ruby/gems/shared/specifications/default"
+
+            PATH="$jruby_bin:$PATH"
+
+            install_default_gem() {
+              gem_file="$1"
+              gem_name="$2"
+              fixed_spec="$3"
+
+              unpack_dir="/tmp/${fixed_spec}-gem"
+              rm -rf "$unpack_dir"
+              mkdir -p "$unpack_dir"
+
+              gem unpack "$gem_file" --target "$unpack_dir"
+              cp -a "$unpack_dir/$fixed_spec/lib/." "$jruby_stdlib/"
+              version="${fixed_spec#${gem_name}-}"
+              cat > "$default_spec_dir/$fixed_spec.gemspec" << EOF
+            Gem::Specification.new do |s|
+              s.name = "$gem_name"
+              s.version = "$version"
+              s.summary = "$gem_name"
+              s.files = []
+              s.require_paths = ["lib"]
+            end
+            EOF
+
+              find "$jruby_stdlib" -type f -name "$gem_name.gemspec" -delete
+              find "$shared_spec_dir" -maxdepth 1 -type f -name "$gem_name-*.gemspec" -delete
+              find "$default_spec_dir" -type f -name "$gem_name-*.gemspec" ! -name "$fixed_spec.gemspec" -delete
+              rm -rf "$unpack_dir"
+            }
+
+            install_fixed_gem() {
+              gem_file="$1"
+              gem_name="$2"
+              fixed_spec="$3"
+              prune_bundle="$4"
+
+              gem install "$gem_file" --local --install-dir "$bundle_dir" --no-document --ignore-dependencies --force
+
+              if [ "$prune_bundle" = "true" ]; then
+                find "$bundle_dir/gems" -maxdepth 1 -type d -name "$gem_name-*" ! -name "$fixed_spec" -exec rm -rf {} +
+                find "$bundle_dir/specifications" -type f -name "$gem_name-*.gemspec" ! -name "$fixed_spec.gemspec" -delete
+              fi
+
+              find "$default_spec_dir" -type f -name "$gem_name-*.gemspec" -delete
+              find "$shared_spec_dir" -maxdepth 1 -type f -name "$gem_name-*.gemspec" -delete
+            }
+
+            install_default_gem "${source.dir}/patch/deps/cgi-0.3.7.gem" cgi cgi-0.3.7
+            install_default_gem "${source.dir}/patch/deps/erb-4.0.3.1.gem" erb erb-4.0.3.1
+            # net-imap 0.5.14 pins older lines that shipped vulnerable net-imap (< 0.5.14).
+            # Logstash 9.4+ ships net-imap 0.6.3; CVE-2026-42245/42246/42256/42257/42258
+            # require 0.6.4+ (do not downgrade to 0.5.14 on those lines).
+            case "9.4" in
+              8.19 | 9.1 | 9.2 | 9.3)
+                install_default_gem "${source.dir}/patch/deps/net-imap-0.5.14.gem" net-imap net-imap-0.5.14
+                install_fixed_gem "${source.dir}/patch/deps/net-imap-0.5.14.gem" net-imap net-imap-0.5.14 true
+                ;;
+              9.4)
+                install_default_gem "${source.dir}/patch/deps/net-imap-0.6.4.gem" net-imap net-imap-0.6.4
+                install_fixed_gem "${source.dir}/patch/deps/net-imap-0.6.4.gem" net-imap net-imap-0.6.4 true
+                sed -i 's/net-imap (0\.6\.3)/net-imap (0.6.4)/g' "${target.dir}/usr/share/logstash/Gemfile.lock"
+                ;;
+            esac
+            install_fixed_gem "${source.dir}/patch/deps/nokogiri-1.19.3-java.gem" nokogiri nokogiri-1.19.3-java true
+            sed -i 's/nokogiri (1\.18\.10-java)/nokogiri (1.19.3-java)/' "${target.dir}/usr/share/logstash/Gemfile.lock"
+            sed -i 's/>= 3\.2/>= 3.1/' "$bundle_dir/specifications/nokogiri-1.19.3-java.gemspec"
+            install_default_gem "${source.dir}/patch/deps/rexml-3.4.4.gem" rexml rexml-3.4.4
+            install_default_gem "${source.dir}/patch/deps/uri-0.12.5.gem" uri uri-0.12.5
+        - name: replace vulnerable bouncycastle jars
+          work-dir: ${source.dir}/logstash
+          runs: |
+            set -eux -o pipefail
+
+            base="${target.dir}/usr/share/logstash"
+
+            replace_bouncycastle_jar() {
+              artifact="$1"
+              fixed="${source.dir}/patch/deps/${artifact}-1.84.jar"
+
+              find "$base" -path "*/org/bouncycastle/$artifact/*/${artifact}-*.jar" -type f | while read -r old_jar; do
+                old_version_dir=$(dirname "$old_jar")
+                artifact_dir=$(dirname "$old_version_dir")
+                fixed_dir="$artifact_dir/1.84"
+
+                echo "Replacing $old_jar with $fixed_dir/${artifact}-1.84.jar"
+                rm "$old_jar"
+                rmdir "$old_version_dir" 2> /dev/null || true
+                mkdir -p "$fixed_dir"
+                cp "$fixed" "$fixed_dir/${artifact}-1.84.jar"
+              done
+            }
+
+            replace_bouncycastle_jar bcprov-jdk18on
+            replace_bouncycastle_jar bcpkix-jdk18on
+            replace_bouncycastle_jar bcutil-jdk18on
+            replace_bouncycastle_jar bctls-jdk18on
+
+            find "$base" -path "*/jopenssl/version.rb" -type f -exec sed -i "s/BOUNCY_CASTLE_VERSION = '[0-9.]*'/BOUNCY_CASTLE_VERSION = '1.84'/" {} +
+      paths:
+        - type: directory
+          path: ${source.dir}/patch
+          uid: 0
+          gid: 0
+          source: image/logstash/patch
+      outputs:
+        - source: ${target.dir}/usr/share/logstash
+          target: /usr/share/logstash
+          uid: 0
+          gid: 0
+          mode: "0755"
+        - source: /opt/docker/sbom/logstash
+          target: /opt/docker/sbom/logstash
+          uid: 0
+          gid: 0
+        - source: ${source.dir}/logstash/docker/data/logstash/bin/docker-entrypoint
+          target: /usr/local/bin/docker-entrypoint
+          uid: 0
+          gid: 0
+          mode: "0755"
+        - source: ${source.dir}/logstash/docker/data/logstash/config/pipelines.yml
+          target: /usr/share/logstash/config/pipelines.yml
+          uid: 1000
+          gid: 0
+          mode: "0644"
+        - source: ${source.dir}/logstash/docker/data/logstash/config/log4j2.properties
+          target: /usr/share/logstash/config/log4j2.properties
+          uid: 1000
+          gid: 0
+          mode: "0644"
+        - source: ${source.dir}/logstash/docker/data/logstash/config/log4j2.file.properties
+          target: /usr/share/logstash/config/log4j2.file.properties
+          uid: 1000
+          gid: 0
+          mode: "0644"
+        - source: ${source.dir}/logstash/docker/data/logstash/config/logstash-oss.yml
+          target: /usr/share/logstash/config/logstash.yml
+          uid: 1000
+          gid: 0
+          mode: "0644"
+        - source: ${source.dir}/logstash/docker/data/logstash/pipeline/default.conf
+          target: /usr/share/logstash/pipeline/logstash.conf
+          uid: 1000
+          gid: 0
+          mode: "0644"
+    - name: locale
+      contents:
+        packages:
+          - bash
+          - locales
+          - coreutils
+          - gzip
+      pipeline:
+        - name: install locales
+          runs: |
+            set -eux -o pipefail
+
+            ln -s /etc/locale.alias /usr/share/locale/locale.alias
+
+            echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+            locale-gen en_US.UTF-8
+      outputs:
+        - source: /usr/share/locale
+          target: /usr/share/locale
+          uid: 0
+          gid: 0
+        - source: /usr/lib/locale
+          target: /usr/lib/locale
+          uid: 0
+          gid: 0
+  artifacts:
+    - name: dhi.io/eclipse-temurin:21.0.11.10-jdk-debian13-dev@sha256:bbe0dfdd7ea19a8d0756efb3c1f96e2d7c70688776e49c0e96142820373027bc
+      includes:
+        - opt/**
+        - usr/local/bin/**
+      uid: 0
+      gid: 0
+accounts:
+  run-as: logstash
+  users:
+    - name: logstash
+      uid: 1000
+      gid: 1000
+  groups:
+    - name: logstash
+      gid: 1000
+      members:
+        - logstash
+os-release:
+  name: Docker Hardened Images (Debian)
+  id: debian
+  version-id: "13"
+  version-codename: trixie
+  pretty-name: Docker Hardened Images/Debian GNU/Linux 13 (trixie)
+  home-url: https://docker.com/products/hardened-images/
+  bug-report-url: https://docker.com/support/
+work-dir: /usr/share/logstash
+environment:
+  ELASTIC_CONTAINER: "true"
+  LANG: en_US.UTF-8
+  LANGUAGE: en_US:en
+  LC_ALL: en_US.UTF-8
+  PATH: /usr/share/logstash/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+paths:
+  - type: directory
+    path: /usr/share/logstash
+    uid: 0
+    gid: 0
+    mode: "0755"
+  - type: directory
+    path: /usr/share/logstash/data
+    uid: 1000
+    gid: 0
+    mode: "2755"
+  - type: directory
+    path: /usr/share/logstash/logs
+    uid: 1000
+    gid: 0
+    mode: "2755"
+  - type: symlink
+    path: /opt/logstash
+    uid: 0
+    gid: 0
+    source: /usr/share/logstash
+  - type: symlink
+    path: /usr/share/logstash/jdk
+    uid: 0
+    gid: 0
+    source: /opt/java/openjdk/21
+annotations:
+  org.opencontainers.image.description: A minimal logstash image
+  org.opencontainers.image.licenses: Elastic-License-2.0
+entrypoint:
+  - /usr/local/bin/docker-entrypoint
+ports:
+  - 9600/tcp
+  - 5044/tcp


### PR DESCRIPTION
Fixes #413

## What

Adds a `compat` variant for Logstash 9.4 on debian-13 (`image/logstash/debian-13/9.4-compat.yaml`), mirroring the existing `8.19-compat.yaml`.

## Why

The compat variants were introduced in [887c20f8a](https://github.com/docker-hardened-images/catalog/commit/887c20f8a19c661af9b8b0d79f13956d08b0499a) for the 8.18, 8.19, 9.1, 9.2 and 9.3 lines, but 9.4 (added later in [ab66f83a4](https://github.com/docker-hardened-images/catalog/commit/ab66f83a44792503d9797779ad830807e683def4)) shipped without one. As a result the 9.4 image is missing `openssl`, which the compat flavor provides and which is needed by out of the box eck operator when creating logstash. 

## Changes

Built from `9.4.yaml` using the same transformation as `8.19-compat.yaml`:

- `name` suffixed with `(compat)` and `flavor: compat` added
- tags rewritten with the `-compat` suffix
- `openssl` added to the top-level package list
- `locale` build layer added (installs `en_US.UTF-8`)
- `LANG`/`LANGUAGE`/`LC_ALL` environment variables set

The diff against `9.4.yaml` is identical in shape to the `8.19.yaml` → `8.19-compat.yaml` diff.

