### PR TITLE
alloy: add libzstd1 and liblzma5 for journal decompression

### DIFF
--- a/image/alloy/debian-13/1-dev.yaml
+++ b/image/alloy/debian-13/1-dev.yaml
@@ -45,7 +45,9 @@ contents:
     - grep
     - libc-bin
     - libc6
+    - liblzma5
     - libsystemd0
+    - libzstd1
     - mawk
     - perl-base
     - sed

--- a/image/alloy/debian-13/1.yaml
+++ b/image/alloy/debian-13/1.yaml
@@ -33,7 +33,9 @@ contents:
     - base-files
     - ca-certificates-bundle
     - libc6
+    - liblzma5
     - libsystemd0
+    - libzstd1
     - tzdata
   builds:
     - name: alloy


### PR DESCRIPTION
## Description

The `alloy` runtime image ships `libsystemd0` but not `libzstd1`. libsystemd `dlopen`s `libzstd.so.1` at runtime to decode zstd-compressed journal fields — the default journal compression since systemd 246 (2020). Without it, the `loki.source.journal` component fails on every entry with `failed to read message field: operation not supported` (EOPNOTSUPP from `sd_journal_get_data()`) and silently forwards nothing, while still reporting the component as healthy.

This adds `libzstd1` and `liblzma5` to the runtime package list of both variants. Both dependencies are declared by the `libsystemd0` package itself (`Recommends: libzstd1`, `Suggests: liblzma5`) and by libsystemd's embedded dlopen feature manifest (`"feature":"zstd","priority":"recommended"`); since the image builder intentionally does not install Recommends, listing them explicitly is the intended mechanism. `liblzma5` covers legacy XZ-compressed journals. Combined size is ~800 KB; both are plain compression libraries already used as runtime dependencies elsewhere in the catalog (e.g. `percona-xtrabackup`, `pgvector`, `python`).

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #388

## Changes Made

- Add `libzstd1` and `liblzma5` to `contents.packages` in `image/alloy/debian-13/1.yaml`
- Add the same packages to `image/alloy/debian-13/1-dev.yaml`

## Testing

- [x] I have tested these changes locally

Verified end-to-end against a real zstd-compressed journal (created with `systemd-journal-remote` 257, file header shows `Incompatible flags: COMPRESSED-ZSTD`), using the reproduction config from #388 with `loki.echo` as the sink:

| Image | `operation not supported` errors | Entries forwarded |
|---|---|---|
| `dhi.io/alloy:1.16.2` (published) | continuous | 0 of 5 |
| same + `libzstd1`/`liblzma5` from the DHI trixie repo | 0 | 5 of 5 |

Also verified that a minimal build through the `dhi.io/build:2-debian13` frontend with the updated package list resolves both packages from the DHI Debian repo and places `libzstd.so.1`/`liblzma.so.5` next to `libsystemd.so.0.40.0` in the final filesystem. (A full local pipeline build wasn't possible — it requires access to the private `definitions` repo and SBOM indexer.)

## Checklist

- [x] My changes follow the repository's style and conventions
- [x] I have updated documentation as needed
- [x] My commit messages are clear and descriptive

---

> **By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
