### PR TITLE
Update PHP examples to use PIE for extension installation + fix paths

### DIFF
--- a/image/php/guides.md
+++ b/image/php/guides.md
@@ -68,19 +68,17 @@ FROM dhi.io/php:<tag>-dev AS builder
 WORKDIR /tmp
 ```
 
-Example of building Redis extension manually:
+Example of installing the Redis extension using [PIE](https://github.com/php/pie):
 
 ```dockerfile
-RUN pecl install redis
+FROM dhi.io/php:<tag>-dev AS builder
+
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+    pie --no-interaction install phpredis/phpredis;
 
 FROM dhi.io/php:<tag>-fpm
-COPY --from=builder $PHP_PREFIX/lib/php/extensions $PHP_PREFIX/lib/php/extensions
-```
-
-Add extension configuration:
-
-```dockerfile
-RUN echo "extension=redis.so" > $PHP_INI_DIR/conf.d/redis.ini
+COPY --from=builder $PHP_INI_DIR/conf.d/* $PHP_INI_DIR/conf.d/
+COPY --from=builder /usr/lib/php/extensions /usr/lib/php/extensions
 ```
 
 ## Non-hardened images vs. Docker Hardened Images
@@ -281,22 +279,17 @@ modern `hash` extension instead.
 
 Use a multi-stage build to compile extensions using the standard PHP build process.
 
-Building an extension from PECL:
+Installing an extension using [PIE](https://github.com/php/pie):
 
 ```dockerfile
 FROM dhi.io/php:<tag>-dev AS builder
-WORKDIR /tmp
-RUN pecl download redis \
-    && tar xzf redis-*.tgz \
-    && cd redis-* \
-    && phpize \
-    && ./configure \
-    && make \
-    && make install
+
+RUN --mount=type=bind,from=ghcr.io/php/pie:bin,source=/pie,target=/usr/local/bin/pie \
+    pie --no-interaction install phpredis/phpredis;
 
 FROM dhi.io/php:<tag>-fpm
-COPY --from=builder /usr/local/lib/php/extensions /usr/local/lib/php/extensions
-RUN echo "extension=redis.so" > $PHP_INI_DIR/conf.d/redis.ini
+COPY --from=builder /usr/lib/php/extensions /usr/lib/php/extensions
+COPY --from=builder $PHP_INI_DIR/conf.d/* $PHP_INI_DIR/conf.d/
 ```
 
 Building an extension from source:


### PR DESCRIPTION
## Description

PHP's PECL repository has be deprecated and at some point will be taken offline. The recommended way to install PHP extensions now is via PIE. See https://github.com/php/pie

## Type of Change

- [x ] Documentation improvement or correction

## Changes Made

* Switched examples of installing extensions in the PHP guide from PECL to PIE
* Fixed references to non-existent paths in examples

**Note**: the examples still do not work due to the `$PHP_INI_DIR` environment variable muddle flagged in #378. I'm assuming that'll be fixed at some point.

## Testing

Built a docker file locally using the example (after hardcoding `$PHP_INI_DIR`).

- [* ] I have tested these changes locally

## Checklist

- [x] My changes follow the repository's style and conventions
- [x] I have updated documentation as needed
- [x] My commit messages are clear and descriptive

---

> **By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
