### PR TITLE
Remove shell from php alpine production builds

### DIFF
--- a/image/php/alpine-3.22/8.2-fpm.yaml
+++ b/image/php/alpine-3.22/8.2-fpm.yaml
@@ -31,7 +31,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.22/8.2.yaml
+++ b/image/php/alpine-3.22/8.2.yaml
@@ -30,7 +30,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.22/8.3-fpm.yaml
+++ b/image/php/alpine-3.22/8.3-fpm.yaml
@@ -31,7 +31,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.22/8.3.yaml
+++ b/image/php/alpine-3.22/8.3.yaml
@@ -30,7 +30,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.22/8.4-fpm.yaml
+++ b/image/php/alpine-3.22/8.4-fpm.yaml
@@ -31,7 +31,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.22/8.4.yaml
+++ b/image/php/alpine-3.22/8.4.yaml
@@ -30,7 +30,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.22/8.5-fpm.yaml
+++ b/image/php/alpine-3.22/8.5-fpm.yaml
@@ -30,7 +30,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.22/8.5.yaml
+++ b/image/php/alpine-3.22/8.5.yaml
@@ -29,7 +29,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.23/8.2-fpm.yaml
+++ b/image/php/alpine-3.23/8.2-fpm.yaml
@@ -29,7 +29,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.23/8.2.yaml
+++ b/image/php/alpine-3.23/8.2.yaml
@@ -28,7 +28,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.23/8.3-fpm.yaml
+++ b/image/php/alpine-3.23/8.3-fpm.yaml
@@ -29,7 +29,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.23/8.3.yaml
+++ b/image/php/alpine-3.23/8.3.yaml
@@ -28,7 +28,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.23/8.4-fpm.yaml
+++ b/image/php/alpine-3.23/8.4-fpm.yaml
@@ -30,7 +30,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.23/8.4.yaml
+++ b/image/php/alpine-3.23/8.4.yaml
@@ -29,7 +29,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.23/8.5-fpm.yaml
+++ b/image/php/alpine-3.23/8.5-fpm.yaml
@@ -31,7 +31,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.23/8.5.yaml
+++ b/image/php/alpine-3.23/8.5.yaml
@@ -30,7 +30,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.24/8.2-fpm.yaml
+++ b/image/php/alpine-3.24/8.2-fpm.yaml
@@ -31,7 +31,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.24/8.2.yaml
+++ b/image/php/alpine-3.24/8.2.yaml
@@ -30,7 +30,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.24/8.3-fpm.yaml
+++ b/image/php/alpine-3.24/8.3-fpm.yaml
@@ -31,7 +31,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.24/8.3.yaml
+++ b/image/php/alpine-3.24/8.3.yaml
@@ -30,7 +30,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.24/8.4-fpm.yaml
+++ b/image/php/alpine-3.24/8.4-fpm.yaml
@@ -32,7 +32,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.24/8.4.yaml
+++ b/image/php/alpine-3.24/8.4.yaml
@@ -31,7 +31,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.24/8.5-fpm.yaml
+++ b/image/php/alpine-3.24/8.5-fpm.yaml
@@ -34,7 +34,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs

--- a/image/php/alpine-3.24/8.5.yaml
+++ b/image/php/alpine-3.24/8.5.yaml
@@ -33,7 +33,6 @@ contents:
   packages:
     - alpine-baselayout-data
     - argon2-libs
-    - busybox
     - ca-certificates-bundle
     - icu-data-full
     - icu-libs


### PR DESCRIPTION
## Description

Fix PHP Alpine production images including `/bin/sh`

## Type of Change

- [ x] Bug fix

## Related Issues

<!-- Link to any related issues using #issue_number -->

Fixes #423 

## Changes Made

<!-- List the specific changes you made -->

- Removed `busybox` package from production images

## Testing

- [x ] I have tested these changes locally

Note: to test locally you have to remove the `PHP_BUILD_PROVIDER: https://github.com/docker-hardened-images/definitions` line from the environment setup in the relevant PHP package YAML. See #327.

## Checklist

- [x ] My changes follow the repository's style and conventions
- [ ] I have updated documentation as needed
- [x ] My commit messages are clear and descriptive

---

> **By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
