### PR TITLE
Remove PHP_BUILD_PROVIDER from alpine3.23 php builds

### DIFF
--- a/package/apk/main/php/alpine-3.23/8.2.yaml
+++ b/package/apk/main/php/alpine-3.23/8.2.yaml
@@ -36,7 +36,6 @@ contents:
         CFLAGS: -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
         CPPFLAGS: -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
         LDFLAGS: -Wl,-O1 -pie
-        PHP_BUILD_PROVIDER: https://github.com/docker-hardened-images/definitions
         PHP_UNAME: Linux - Docker Hardened Images
       contents:
         packages:

--- a/package/apk/main/php/alpine-3.23/8.3.yaml
+++ b/package/apk/main/php/alpine-3.23/8.3.yaml
@@ -36,7 +36,6 @@ contents:
         CFLAGS: -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
         CPPFLAGS: -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
         LDFLAGS: -Wl,-O1 -pie
-        PHP_BUILD_PROVIDER: https://github.com/docker-hardened-images/definitions
         PHP_UNAME: Linux - Docker Hardened Images
       contents:
         packages:

--- a/package/apk/main/php/alpine-3.23/8.4.yaml
+++ b/package/apk/main/php/alpine-3.23/8.4.yaml
@@ -36,7 +36,6 @@ contents:
         CFLAGS: -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
         CPPFLAGS: -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
         LDFLAGS: -Wl,-O1 -pie
-        PHP_BUILD_PROVIDER: https://github.com/docker-hardened-images/definitions
         PHP_UNAME: Linux - Docker Hardened Images
       contents:
         packages:

--- a/package/apk/main/php/alpine-3.23/8.5.yaml
+++ b/package/apk/main/php/alpine-3.23/8.5.yaml
@@ -36,7 +36,6 @@ contents:
         CFLAGS: -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
         CPPFLAGS: -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
         LDFLAGS: -Wl,-O1 -pie
-        PHP_BUILD_PROVIDER: https://github.com/docker-hardened-images/definitions
         PHP_UNAME: Linux - Docker Hardened Images
       contents:
         packages:

--- a/package/apk/main/php/alpine-3.24/8.2.yaml
+++ b/package/apk/main/php/alpine-3.24/8.2.yaml
@@ -37,7 +37,6 @@ contents:
         CFLAGS: -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
         CPPFLAGS: -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
         LDFLAGS: -Wl,-O1 -pie
-        PHP_BUILD_PROVIDER: https://github.com/docker-hardened-images/definitions
         PHP_UNAME: Linux - Docker Hardened Images
       contents:
         packages:

--- a/package/apk/main/php/alpine-3.24/8.3.yaml
+++ b/package/apk/main/php/alpine-3.24/8.3.yaml
@@ -37,7 +37,6 @@ contents:
         CFLAGS: -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
         CPPFLAGS: -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
         LDFLAGS: -Wl,-O1 -pie
-        PHP_BUILD_PROVIDER: https://github.com/docker-hardened-images/definitions
         PHP_UNAME: Linux - Docker Hardened Images
       contents:
         packages:

--- a/package/apk/main/php/alpine-3.24/8.4.yaml
+++ b/package/apk/main/php/alpine-3.24/8.4.yaml
@@ -37,7 +37,6 @@ contents:
         CFLAGS: -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
         CPPFLAGS: -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
         LDFLAGS: -Wl,-O1 -pie
-        PHP_BUILD_PROVIDER: https://github.com/docker-hardened-images/definitions
         PHP_UNAME: Linux - Docker Hardened Images
       contents:
         packages:

--- a/package/apk/main/php/alpine-3.24/8.5.yaml
+++ b/package/apk/main/php/alpine-3.24/8.5.yaml
@@ -37,7 +37,6 @@ contents:
         CFLAGS: -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
         CPPFLAGS: -fstack-protector-strong -fpic -fpie -O2 -D_LARGEFILE_SOURCE -D_FILE_OFFSET_BITS=64
         LDFLAGS: -Wl,-O1 -pie
-        PHP_BUILD_PROVIDER: https://github.com/docker-hardened-images/definitions
         PHP_UNAME: Linux - Docker Hardened Images
       contents:
         packages:


### PR DESCRIPTION
## Description

I have no idea what `PHP_BUILD_PROVIDER` does, except it causes local builds to fail with 

```
ERROR: failed to build: failed to solve: failed to load cache key: failed to fetch remote https://github.com/docker-hardened-images/definitions.git: git stderr:
fatal: could not read Username for 'https://github.com': terminal prompts disabled
: exit status 128
```

The reference repository appears to be private.

Note that the same line appears in the alpine3.22 and debian13 _image_ definitions, but unfortunately removing those doesn't help: the local builds on those still fail with the same error 😞 Perhaps if someone can give an idea what the build provider does and where it's called from I can make some progress.

## Type of Change

<!-- Please check the relevant option(s) -->

- [x] Bug fix

## Related Issues

<!-- Link to any related issues using #issue_number -->

Partial fix for #327 

## Changes Made

Removed the `PHP_BUILD_PROVIDER: https://github.com/docker-hardened-images/definitions` line from the `environment` section of the alpine php packages.

Note that this line is also present 

## Testing

I built all php versions on alpine-3.23 locally.

- [x] I have tested these changes locally
- [ ] All existing tests pass
- [ ] I have added new tests (if applicable)

## Checklist

- [x] My changes follow the repository's style and conventions
- [ ] I have updated documentation as needed
- [x] My commit messages are clear and descriptive

---

> **By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
