### PR TITLE
litellm: update to 1.89.2

### DIFF
--- a/image/litellm/debian-13/1-dev.yaml
+++ b/image/litellm/debian-13/1-dev.yaml
@@ -5,32 +5,32 @@ image: dhi.io/litellm
 variant: dev
 tags:
   - 1-dev
-  - 1.84-dev
-  - 1.84.0-dev
+  - 1.89-dev
+  - 1.89.2-dev
   - 1-debian-dev
   - 1-debian13-dev
-  - 1.84-debian-dev
-  - 1.84-debian13-dev
-  - 1.84.0-debian-dev
-  - 1.84.0-debian13-dev
+  - 1.89-debian-dev
+  - 1.89-debian13-dev
+  - 1.89.2-debian-dev
+  - 1.89.2-debian13-dev
 platforms:
   - linux/amd64
   - linux/arm64
 vars:
-  _COMMIT_SHA: e1fc955464bf493c15aef08f98e0e22bdf24d4cf
-  _VERSION: 1.84.0
-  COMMIT_SHA: e1fc955464bf493c15aef08f98e0e22bdf24d4cf
-  DEBIAN_EPOCH_MAJOR_MINOR_VERSION: "1.84"
+  _COMMIT_SHA: 94dae27b0c555d2549ee5077a16d6ea5542244bd
+  _VERSION: 1.89.2
+  COMMIT_SHA: 94dae27b0c555d2549ee5077a16d6ea5542244bd
+  DEBIAN_EPOCH_MAJOR_MINOR_VERSION: "1.89"
   DEBIAN_EPOCH_MAJOR_VERSION: "1"
-  DEBIAN_EPOCH_VERSION: 1.84.0
+  DEBIAN_EPOCH_VERSION: 1.89.2
   PYTHON_BUILD_REFERENCE: dhi/python:3.13.14-debian13-dev@sha256:30d3f2a63f025d6a77268c209ab740b00073da6fc90857833570e08a8c95836c
   PYTHON_BUILD_VERSION: 3.13.14
   PYTHON_REFERENCE: dhi/python:3.13.14-debian13@sha256:930f26cbc1f72de2e7cbe31c597a74b01a08489dbe04e53804d96f9251ffd3a8
   PYTHON_VERSION: 3.13.14
-  SEMVER_MAJOR_MINOR_VERSION: "1.84"
+  SEMVER_MAJOR_MINOR_VERSION: "1.89"
   SEMVER_MAJOR_VERSION: "1"
-  SEMVER_VERSION: 1.84.0
-  VERSION: 1.84.0
+  SEMVER_VERSION: 1.89.2
+  VERSION: 1.89.2
 contents:
   packages:
     - '!gawk'
@@ -72,15 +72,15 @@ contents:
           - gzip
           - '!libexpat1'
         files:
-          - url: git+https://github.com/BerriAI/litellm.git#e1fc955464bf493c15aef08f98e0e22bdf24d4cf
-            checksum: e1fc955464bf493c15aef08f98e0e22bdf24d4cf
+          - url: git+https://github.com/BerriAI/litellm.git#94dae27b0c555d2549ee5077a16d6ea5542244bd
+            checksum: 94dae27b0c555d2549ee5077a16d6ea5542244bd
             path: ${source.dir}/litellm-src
             spdx:
               name: litellm
-              version: 1.84.0
+              version: 1.89.2
               packages:
                 - name: litellm
-                  purl: pkg:pypi/litellm@1.84.0
+                  purl: pkg:pypi/litellm@1.89.2
                   license: MIT
             uid: 0
             gid: 0

--- a/image/litellm/debian-13/1.yaml
+++ b/image/litellm/debian-13/1.yaml
@@ -5,32 +5,32 @@ image: dhi.io/litellm
 variant: runtime
 tags:
   - "1"
-  - "1.84"
-  - 1.84.0
+  - "1.89"
+  - 1.89.2
   - 1-debian
   - 1-debian13
-  - 1.84-debian
-  - 1.84-debian13
-  - 1.84.0-debian
-  - 1.84.0-debian13
+  - 1.89-debian
+  - 1.89-debian13
+  - 1.89.2-debian
+  - 1.89.2-debian13
 platforms:
   - linux/amd64
   - linux/arm64
 vars:
-  _COMMIT_SHA: e1fc955464bf493c15aef08f98e0e22bdf24d4cf
-  _VERSION: 1.84.0
-  COMMIT_SHA: e1fc955464bf493c15aef08f98e0e22bdf24d4cf
-  DEBIAN_EPOCH_MAJOR_MINOR_VERSION: "1.84"
+  _COMMIT_SHA: 94dae27b0c555d2549ee5077a16d6ea5542244bd
+  _VERSION: 1.89.2
+  COMMIT_SHA: 94dae27b0c555d2549ee5077a16d6ea5542244bd
+  DEBIAN_EPOCH_MAJOR_MINOR_VERSION: "1.89"
   DEBIAN_EPOCH_MAJOR_VERSION: "1"
-  DEBIAN_EPOCH_VERSION: 1.84.0
+  DEBIAN_EPOCH_VERSION: 1.89.2
   PYTHON_BUILD_REFERENCE: dhi/python:3.13.14-debian13-dev@sha256:30d3f2a63f025d6a77268c209ab740b00073da6fc90857833570e08a8c95836c
   PYTHON_BUILD_VERSION: 3.13.14
   PYTHON_REFERENCE: dhi/python:3.13.14-debian13@sha256:930f26cbc1f72de2e7cbe31c597a74b01a08489dbe04e53804d96f9251ffd3a8
   PYTHON_VERSION: 3.13.14
-  SEMVER_MAJOR_MINOR_VERSION: "1.84"
+  SEMVER_MAJOR_MINOR_VERSION: "1.89"
   SEMVER_MAJOR_VERSION: "1"
-  SEMVER_VERSION: 1.84.0
-  VERSION: 1.84.0
+  SEMVER_VERSION: 1.89.2
+  VERSION: 1.89.2
 contents:
   packages:
     - '!libelogind0'
@@ -61,15 +61,15 @@ contents:
           - gzip
           - '!libexpat1'
         files:
-          - url: git+https://github.com/BerriAI/litellm.git#e1fc955464bf493c15aef08f98e0e22bdf24d4cf
-            checksum: e1fc955464bf493c15aef08f98e0e22bdf24d4cf
+          - url: git+https://github.com/BerriAI/litellm.git#94dae27b0c555d2549ee5077a16d6ea5542244bd
+            checksum: 94dae27b0c555d2549ee5077a16d6ea5542244bd
             path: ${source.dir}/litellm-src
             spdx:
               name: litellm
-              version: 1.84.0
+              version: 1.89.2
               packages:
                 - name: litellm
-                  purl: pkg:pypi/litellm@1.84.0
+                  purl: pkg:pypi/litellm@1.89.2
                   license: MIT
             uid: 0
             gid: 0


### PR DESCRIPTION
## Description

Updates the LiteLLM hardened image from **1.84.0** to **1.89.2**, the latest upstream stable release from [BerriAI/litellm](https://github.com/BerriAI/litellm). This brings DHI in line with the current upstream release as requested in #437.

## Type of Change

- [x] Bug fix (image is out of date)

## Related Issues

Fixes #437

## Changes Made

Updated both `image/litellm/debian-13/1.yaml` (runtime) and `image/litellm/debian-13/1-dev.yaml` (dev):

- Version vars `_VERSION` / `VERSION` / `SEMVER_VERSION` / `DEBIAN_EPOCH_VERSION`: `1.84.0` → `1.89.2`
- `SEMVER_MAJOR_MINOR_VERSION` / `DEBIAN_EPOCH_MAJOR_MINOR_VERSION`: `1.84` → `1.89`
- `_COMMIT_SHA` / `COMMIT_SHA`, source `url` and `checksum`: `e1fc955…` → `94dae27…` (upstream tag [`v1.89.2`](https://github.com/BerriAI/litellm/releases/tag/v1.89.2))
- Image `tags` and SPDX `version` / `purl` (`pkg:pypi/litellm@1.89.2`) updated accordingly

The Python base image references (`3.13.14`), CVE remediations, and npm patches are intentionally left unchanged — this matches the scope of prior LiteLLM version-bump commits.

## Testing

- [x] Both YAML files parse correctly
- [x] Verified commit SHA `94dae27b0c555d2549ee5077a16d6ea5542244bd` matches upstream tag `v1.89.2`
- [x] Confirmed all version/SHA references were updated consistently with no stale `1.84` references remaining

> Note: I was unable to run a full DHI image build locally, as it depends on the `dhi.io/build` toolchain. CI build verification would be appreciated.

## Checklist

- [x] My changes follow the repository's style and conventions
- [x] My commit messages are clear and descriptive

---

> **By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
