### PR TITLE
fix(logstash): keep already-patched jackson-core so the persistent queue doesn't crash

### DIFF
--- a/image/logstash/debian-13/8.19-compat.yaml
+++ b/image/logstash/debian-13/8.19-compat.yaml
@@ -411,11 +411,18 @@ contents:
               cp "$jackson_fixed" "$old_jar"
             done
 
-            # Also replace jackson-core in logstash-core/lib/jars if it exists (8.19+)
+            # Also replace jackson-core in logstash-core/lib/jars if it exists (8.19+),
+            # but only if it is still vulnerable to GHSA-72hv-8253-57qq. The bundled 2.21.2
+            # is already fixed; replacing it would leave incompatible jackson versions.
+            ver_ge() { [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" = "$1" ]; }
             core_jar=$(find "${target.dir}/usr/share/logstash/logstash-core/lib/jars" -name "jackson-core-*.jar" -type f 2> /dev/null | head -1)
             if [ -n "$core_jar" ] && [ -f "$core_jar" ]; then
-              echo "Replacing $core_jar with fixed version"
-              cp "$jackson_fixed" "$core_jar"
+              ver=$(basename "$core_jar" | sed -E 's/^jackson-core-(.*)\.jar$/\1/')
+              # Affected versions: <= 2.18.5, or >= 2.19.0 and < 2.21.1
+              if ! ver_ge "$ver" 2.18.6 || { ver_ge "$ver" 2.19.0 && ! ver_ge "$ver" 2.21.1; }; then
+                echo "Replacing $core_jar with fixed version"
+                cp "$jackson_fixed" "$core_jar"
+              fi
             fi
         - name: patch shaded jackson-core in elastic_integration jar
           runs: |

--- a/image/logstash/debian-13/8.19.yaml
+++ b/image/logstash/debian-13/8.19.yaml
@@ -409,11 +409,18 @@ contents:
               cp "$jackson_fixed" "$old_jar"
             done
 
-            # Also replace jackson-core in logstash-core/lib/jars if it exists (8.19+)
+            # Also replace jackson-core in logstash-core/lib/jars if it exists (8.19+),
+            # but only if it is still vulnerable to GHSA-72hv-8253-57qq. The bundled 2.21.2
+            # is already fixed; replacing it would leave incompatible jackson versions.
+            ver_ge() { [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" = "$1" ]; }
             core_jar=$(find "${target.dir}/usr/share/logstash/logstash-core/lib/jars" -name "jackson-core-*.jar" -type f 2> /dev/null | head -1)
             if [ -n "$core_jar" ] && [ -f "$core_jar" ]; then
-              echo "Replacing $core_jar with fixed version"
-              cp "$jackson_fixed" "$core_jar"
+              ver=$(basename "$core_jar" | sed -E 's/^jackson-core-(.*)\.jar$/\1/')
+              # Affected versions: <= 2.18.5, or >= 2.19.0 and < 2.21.1
+              if ! ver_ge "$ver" 2.18.6 || { ver_ge "$ver" 2.19.0 && ! ver_ge "$ver" 2.21.1; }; then
+                echo "Replacing $core_jar with fixed version"
+                cp "$jackson_fixed" "$core_jar"
+              fi
             fi
         - name: patch shaded jackson-core in elastic_integration jar
           runs: |

--- a/image/logstash/debian-13/9.4-compat.yaml
+++ b/image/logstash/debian-13/9.4-compat.yaml
@@ -448,11 +448,18 @@ contents:
               cp "$jackson_fixed" "$old_jar"
             done
 
-            # Also replace jackson-core in logstash-core/lib/jars if it exists (8.19+)
+            # Also replace jackson-core in logstash-core/lib/jars if it exists (8.19+),
+            # but only if it is still vulnerable to GHSA-72hv-8253-57qq. The bundled 2.21.2
+            # is already fixed; replacing it would leave incompatible jackson versions.
+            ver_ge() { [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" = "$1" ]; }
             core_jar=$(find "${target.dir}/usr/share/logstash/logstash-core/lib/jars" -name "jackson-core-*.jar" -type f 2> /dev/null | head -1)
             if [ -n "$core_jar" ] && [ -f "$core_jar" ]; then
-              echo "Replacing $core_jar with fixed version"
-              cp "$jackson_fixed" "$core_jar"
+              ver=$(basename "$core_jar" | sed -E 's/^jackson-core-(.*)\.jar$/\1/')
+              # Affected versions: <= 2.18.5, or >= 2.19.0 and < 2.21.1
+              if ! ver_ge "$ver" 2.18.6 || { ver_ge "$ver" 2.19.0 && ! ver_ge "$ver" 2.21.1; }; then
+                echo "Replacing $core_jar with fixed version"
+                cp "$jackson_fixed" "$core_jar"
+              fi
             fi
         - name: patch shaded jackson-core in elastic_integration jar
           runs: |

--- a/image/logstash/debian-13/9.4.yaml
+++ b/image/logstash/debian-13/9.4.yaml
@@ -446,11 +446,18 @@ contents:
               cp "$jackson_fixed" "$old_jar"
             done
 
-            # Also replace jackson-core in logstash-core/lib/jars if it exists (8.19+)
+            # Also replace jackson-core in logstash-core/lib/jars if it exists (8.19+),
+            # but only if it is still vulnerable to GHSA-72hv-8253-57qq. The bundled 2.21.2
+            # is already fixed; replacing it would leave incompatible jackson versions.
+            ver_ge() { [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -n1)" = "$1" ]; }
             core_jar=$(find "${target.dir}/usr/share/logstash/logstash-core/lib/jars" -name "jackson-core-*.jar" -type f 2> /dev/null | head -1)
             if [ -n "$core_jar" ] && [ -f "$core_jar" ]; then
-              echo "Replacing $core_jar with fixed version"
-              cp "$jackson_fixed" "$core_jar"
+              ver=$(basename "$core_jar" | sed -E 's/^jackson-core-(.*)\.jar$/\1/')
+              # Affected versions: <= 2.18.5, or >= 2.19.0 and < 2.21.1
+              if ! ver_ge "$ver" 2.18.6 || { ver_ge "$ver" 2.19.0 && ! ver_ge "$ver" 2.21.1; }; then
+                echo "Replacing $core_jar with fixed version"
+                cp "$jackson_fixed" "$core_jar"
+              fi
             fi
         - name: patch shaded jackson-core in elastic_integration jar
           runs: |


### PR DESCRIPTION
## Description

The `replace vulnerable jackson-core jars` step overwrote **only** `jackson-core` in `logstash-core/lib/jars` with `2.18.6`, while `jackson-databind` and `jackson-dataformat-cbor` stayed at the bundled `2.21.2`. That leaves multiple incompatible jackson component versions in the image, which crashes Logstash on startup whenever the persistent queue (`queue.type: persisted`) is enabled.

`jackson-core 2.21.2` is **not** affected by `GHSA-72hv-8253-57qq` (the advisory is fixed in `2.18.6` and `>= 2.21.1`), so the downgrade was both unnecessary and the trigger for the crash. This makes that replacement version-aware: `jackson-core` in `logstash-core/lib/jars` is only overwritten when its version is in the advisory's affected ranges, keeping the bundled jackson components at a single consistent version. The vendored-gems replacement is unchanged.

`8.19.16` ships the same `2.21.2` set and the same step, so the fix is applied there too.

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #445

## Changes Made

- `9.4.yaml`, `9.4-compat.yaml`, `8.19.yaml`, `8.19-compat.yaml`: guard the `logstash-core/lib/jars` jackson-core replacement so it only runs for versions affected by `GHSA-72hv-8253-57qq` (`<= 2.18.5`, or `>= 2.19.0 and < 2.21.1`).

## Testing

- [x] I have tested these changes locally
- [ ] All existing tests pass
- [ ] I have added new tests (if applicable)

The DHI build frontend (`# syntax=dhi.io/build`) isn't publicly buildable, so I validated the changed step against `docker.elastic.co/logstash/logstash:9.4.2` (same distribution, same `jackson-* 2.21.x` set in `logstash-core/lib/jars`):

- Applying the old logic and running with `queue.type: persisted` reproduces the exact #445 crash — 0 events processed.
- With the fix, `jackson-core` stays `2.21.2`, the queue replays cleanly, all events flow, and the pipeline starts normally.

## Checklist

- [x] My changes follow the repository's style and conventions
- [ ] I have updated documentation as needed
- [x] My commit messages are clear and descriptive

---

> **By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
