### PR TITLE
traefik: update image to version 3.7.6

### DIFF
--- a/image/traefik/alpine-3.23/3.7-dev.yaml
+++ b/image/traefik/alpine-3.23/3.7-dev.yaml
@@ -31,7 +31,7 @@ contents:
     - apk-tools
     - busybox
     - ca-certificates
-    - traefik-dev=3.7.5-r1
+    - traefik-3.7-dev=3.7.5-r1
 accounts:
   root: true
   run-as: root

--- a/image/traefik/alpine-3.23/3.7-dev.yaml
+++ b/image/traefik/alpine-3.23/3.7-dev.yaml
@@ -6,19 +6,19 @@ variant: dev
 tags:
   - 3-alpine3.23-dev
   - 3.7-alpine3.23-dev
-  - 3.7.5-alpine3.23-dev
+  - 3.7.6-alpine3.23-dev
 platforms:
   - linux/amd64
   - linux/arm64
 dates:
-  release: "2026-05-05"
+  release: "2026-06-30"
 vars:
   FLAVORED_SUFFIX: -dev
   SEMVER_MAJOR_MINOR_VERSION: "3.7"
   SEMVER_MAJOR_VERSION: "3"
-  SEMVER_VERSION: 3.7.5
+  SEMVER_VERSION: 3.7.6
   SUFFIX: -dev
-  VERSION: 3.7.5-r1
+  VERSION: 3.7.6-r1
 contents:
   repositories:
     - https://dhi.io/apk/alpine/v3.23/main
@@ -31,7 +31,7 @@ contents:
     - apk-tools
     - busybox
     - ca-certificates
-    - traefik-3.7-dev=3.7.5-r1
+    - traefik-3.7-dev=3.7.6-r1
 accounts:
   root: true
   run-as: root

--- a/image/traefik/alpine-3.23/3.7.yaml
+++ b/image/traefik/alpine-3.23/3.7.yaml
@@ -6,19 +6,19 @@ variant: runtime
 tags:
   - 3-alpine3.23
   - 3.7-alpine3.23
-  - 3.7.5-alpine3.23
+  - 3.7.6-alpine3.23
 platforms:
   - linux/amd64
   - linux/arm64
 dates:
-  release: "2026-05-05"
+  release: "2026-06-30"
 vars:
   FLAVORED_SUFFIX: ""
   SEMVER_MAJOR_MINOR_VERSION: "3.7"
   SEMVER_MAJOR_VERSION: "3"
-  SEMVER_VERSION: 3.7.5
+  SEMVER_VERSION: 3.7.6
   SUFFIX: ""
-  VERSION: 3.7.5-r1
+  VERSION: 3.7.6-r1
 contents:
   repositories:
     - https://dhi.io/apk/alpine/v3.23/main
@@ -28,7 +28,7 @@ contents:
     - https://dhi.io/keyring/dhi-apk@docker-0F81AD7700D99184.rsa.pub
   packages:
     - alpine-baselayout-data
-    - traefik-3.7=3.7.5-r1
+    - traefik-3.7=3.7.6-r1
 accounts:
   run-as: nonroot
   users:

--- a/image/traefik/alpine-3.23/3.7.yaml
+++ b/image/traefik/alpine-3.23/3.7.yaml
@@ -28,7 +28,7 @@ contents:
     - https://dhi.io/keyring/dhi-apk@docker-0F81AD7700D99184.rsa.pub
   packages:
     - alpine-baselayout-data
-    - traefik=3.7.5-r1
+    - traefik-3.7=3.7.5-r1
 accounts:
   run-as: nonroot
   users:

--- a/image/traefik/alpine-3.24/3.7-dev.yaml
+++ b/image/traefik/alpine-3.24/3.7-dev.yaml
@@ -7,21 +7,21 @@ tags:
   - 3-alpine-dev
   - 3.7-alpine-dev
   - 3-alpine3.24-dev
-  - 3.7.5-alpine-dev
+  - 3.7.6-alpine-dev
   - 3.7-alpine3.24-dev
-  - 3.7.5-alpine3.24-dev
+  - 3.7.6-alpine3.24-dev
 platforms:
   - linux/amd64
   - linux/arm64
 dates:
-  release: "2026-05-05"
+  release: "2026-06-30"
 vars:
   FLAVORED_SUFFIX: -dev
   SEMVER_MAJOR_MINOR_VERSION: "3.7"
   SEMVER_MAJOR_VERSION: "3"
-  SEMVER_VERSION: 3.7.5
+  SEMVER_VERSION: 3.7.6
   SUFFIX: -dev
-  VERSION: 3.7.5-r1
+  VERSION: 3.7.6-r1
 contents:
   repositories:
     - https://dhi.io/apk/alpine/v3.24/main
@@ -34,7 +34,7 @@ contents:
     - apk-tools
     - busybox
     - ca-certificates
-    - traefik-3.7-dev=3.7.5-r1
+    - traefik-3.7-dev=3.7.6-r1
 accounts:
   root: true
   run-as: root

--- a/image/traefik/alpine-3.24/3.7-dev.yaml
+++ b/image/traefik/alpine-3.24/3.7-dev.yaml
@@ -34,7 +34,7 @@ contents:
     - apk-tools
     - busybox
     - ca-certificates
-    - traefik-dev=3.7.5-r1
+    - traefik-3.7-dev=3.7.5-r1
 accounts:
   root: true
   run-as: root

--- a/image/traefik/alpine-3.24/3.7.yaml
+++ b/image/traefik/alpine-3.24/3.7.yaml
@@ -7,21 +7,21 @@ tags:
   - 3-alpine
   - 3.7-alpine
   - 3-alpine3.24
-  - 3.7.5-alpine
+  - 3.7.6-alpine
   - 3.7-alpine3.24
-  - 3.7.5-alpine3.24
+  - 3.7.6-alpine3.24
 platforms:
   - linux/amd64
   - linux/arm64
 dates:
-  release: "2026-05-05"
+  release: "2026-06-30"
 vars:
   FLAVORED_SUFFIX: ""
   SEMVER_MAJOR_MINOR_VERSION: "3.7"
   SEMVER_MAJOR_VERSION: "3"
-  SEMVER_VERSION: 3.7.5
+  SEMVER_VERSION: 3.7.6
   SUFFIX: ""
-  VERSION: 3.7.5-r1
+  VERSION: 3.7.6-r1
 contents:
   repositories:
     - https://dhi.io/apk/alpine/v3.24/main
@@ -31,7 +31,7 @@ contents:
     - https://dhi.io/keyring/dhi-apk@docker-0F81AD7700D99184.rsa.pub
   packages:
     - alpine-baselayout-data
-    - traefik-3.7=3.7.5-r1
+    - traefik-3.7=3.7.6-r1
 accounts:
   run-as: nonroot
   users:

--- a/image/traefik/alpine-3.24/3.7.yaml
+++ b/image/traefik/alpine-3.24/3.7.yaml
@@ -31,7 +31,7 @@ contents:
     - https://dhi.io/keyring/dhi-apk@docker-0F81AD7700D99184.rsa.pub
   packages:
     - alpine-baselayout-data
-    - traefik=3.7.5-r1
+    - traefik-3.7=3.7.5-r1
 accounts:
   run-as: nonroot
   users:

--- a/image/traefik/debian-13/3.7-dev.yaml
+++ b/image/traefik/debian-13/3.7-dev.yaml
@@ -6,25 +6,25 @@ variant: dev
 tags:
   - 3-dev
   - 3.7-dev
-  - 3.7.5-dev
+  - 3.7.6-dev
   - 3-debian-dev
   - 3-debian13-dev
   - 3.7-debian-dev
   - 3.7-debian13-dev
-  - 3.7.5-debian-dev
-  - 3.7.5-debian13-dev
+  - 3.7.6-debian-dev
+  - 3.7.6-debian13-dev
 platforms:
   - linux/amd64
   - linux/arm64
 dates:
-  release: "2026-05-05"
+  release: "2026-06-30"
 vars:
   FLAVORED_SUFFIX: -dev
   SEMVER_MAJOR_MINOR_VERSION: "3.7"
   SEMVER_MAJOR_VERSION: "3"
-  SEMVER_VERSION: 3.7.5
+  SEMVER_VERSION: 3.7.6
   SUFFIX: -dev
-  VERSION: 3.7.5-1
+  VERSION: 3.7.6-1
 contents:
   repositories:
     - deb [signed-by=/usr/share/keyrings/dhi-deb-main.gpg] http://dhi.io/deb/debian/main trixie main
@@ -48,7 +48,7 @@ contents:
     - mawk
     - perl-base
     - sed
-    - traefik-3.7-dev=3.7.5-1
+    - traefik-3.7-dev=3.7.6-1
     - tzdata
     - util-linux
 accounts:

--- a/image/traefik/debian-13/3.7-dev.yaml
+++ b/image/traefik/debian-13/3.7-dev.yaml
@@ -48,7 +48,7 @@ contents:
     - mawk
     - perl-base
     - sed
-    - traefik-dev=3.7.5-1
+    - traefik-3.7-dev=3.7.5-1
     - tzdata
     - util-linux
 accounts:

--- a/image/traefik/debian-13/3.7.yaml
+++ b/image/traefik/debian-13/3.7.yaml
@@ -33,7 +33,7 @@ contents:
   packages:
     - base-files
     - ca-certificates-bundle
-    - traefik=3.7.5-1
+    - traefik-3.7=3.7.5-1
     - tzdata
 accounts:
   run-as: nonroot

--- a/image/traefik/debian-13/3.7.yaml
+++ b/image/traefik/debian-13/3.7.yaml
@@ -6,25 +6,25 @@ variant: runtime
 tags:
   - "3"
   - "3.7"
-  - 3.7.5
+  - 3.7.6
   - 3-debian
   - 3-debian13
   - 3.7-debian
   - 3.7-debian13
-  - 3.7.5-debian
-  - 3.7.5-debian13
+  - 3.7.6-debian
+  - 3.7.6-debian13
 platforms:
   - linux/amd64
   - linux/arm64
 dates:
-  release: "2026-05-05"
+  release: "2026-06-30"
 vars:
   FLAVORED_SUFFIX: ""
   SEMVER_MAJOR_MINOR_VERSION: "3.7"
   SEMVER_MAJOR_VERSION: "3"
-  SEMVER_VERSION: 3.7.5
+  SEMVER_VERSION: 3.7.6
   SUFFIX: ""
-  VERSION: 3.7.5-1
+  VERSION: 3.7.6-1
 contents:
   repositories:
     - deb [signed-by=/usr/share/keyrings/dhi-deb-main.gpg] http://dhi.io/deb/debian/main trixie main
@@ -33,7 +33,7 @@ contents:
   packages:
     - base-files
     - ca-certificates-bundle
-    - traefik-3.7=3.7.5-1
+    - traefik-3.7=3.7.6-1
     - tzdata
 accounts:
   run-as: nonroot


### PR DESCRIPTION
## Description

Hello,

I think fab0f6f677430a1aab25bf5f64a9b5a59afb1cac might have broken @dhi-bot automated updates for `traefik` images.

This PR updates the images to use the new package name and bump version numbers to the latest versions.

## Type of Change

- [x] Bug fix (#469)
- [x] Other: Version bump

## Changes Made

- Use new apk and deb package name `traefik-3.7` (cf fab0f6f677430a1aab25bf5f64a9b5a59afb1cac).
- Update  deb package `traefik-3.7` from `3.7.5-1` to `3.7.6-1`
- Update  apk package `traefik-3.7` from `3.7.5-r1` to `3.7.6-r1`

## Testing

- [x] I have tested these changes locally
- [ ] All existing tests pass
- [ ] I have added new tests (if applicable)

All updated images build for `linux/amd64` and `linux/arm64`.

```bash
for file in $(git diff HEAD main --name-only); do
  docker build --file $file --platform linux/amd64,linux/arm64 . || break
done
```

## Checklist

- [x] My changes follow the repository's style and conventions
- [ ] I have updated documentation as needed
- [x] My commit messages are clear and descriptive

---

> **By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**

Yes.