### PR TITLE
prowler: add API, UI, and MCP images

### DIFF
--- a/image/prowler-api/debian-13/5.yaml
+++ b/image/prowler-api/debian-13/5.yaml
@@ -1,0 +1,303 @@
+# syntax=dhi.io/build:2-debian13
+
+name: Prowler API 5.x
+image: dhi.io/prowler-api
+variant: runtime
+tags:
+  - "5"
+  - "5.36"
+  - 5.36.0
+  - 5-debian
+  - 5-debian13
+  - 5.36-debian
+  - 5.36-debian13
+  - 5.36.0-debian
+  - 5.36.0-debian13
+platforms:
+  - linux/amd64
+  - linux/arm64
+dates:
+  release: "2026-07-24"
+vars:
+  COMMIT_SHA: 685d24dfee4616981e017b1745e3b8f2633d499d
+  POWERSHELL_ARCH: '#{ target.arch == "amd64" ? "x64" : "arm64" }'
+  POWERSHELL_CHECKSUM: '#{ target.arch == "amd64" ? "sha256:7ebb0048a38009de5a59d620a10f33d7ba4920ace2379b104a67fafb79e2841b" : "sha256:a3b6a1d14897974aea732d82970c86dd17ffc57a5fc4f4bfabfe2dd272ff6c40" }'
+  POWERSHELL_VERSION: 7.5.0
+  PYTHON_MAJOR_MINOR_VERSION: "3.12"
+  SEMVER_MAJOR_MINOR_VERSION: "5.36"
+  SEMVER_MAJOR_VERSION: "5"
+  SEMVER_VERSION: 5.36.0
+  ZIZMOR_ARCH: '#{ target.arch == "amd64" ? "x86_64-unknown-linux-gnu" : "aarch64-unknown-linux-gnu" }'
+  ZIZMOR_CHECKSUM: '#{ target.arch == "amd64" ? "sha256:a8000f3c683319a523d3b20df0e75457ba591f049cfcbfa98966631b56733c03" : "sha256:d66e37ef8a375fb07939c630ebf9709a6e0f20242bdc3faf672a7ed97e0b768d" }'
+  ZIZMOR_VERSION: 1.24.1
+  VERSION: 5.36.0
+contents:
+  repositories:
+    - deb [signed-by=/usr/share/keyrings/dhi-deb-main.gpg] http://dhi.io/deb/debian/main trixie main
+  keyring:
+    - https://dhi.io/keyring/dhi-deb-gpg.D46852F6925E9F71.key
+  packages:
+    - base-files
+    - ca-certificates-bundle
+    - dash
+    - hostname
+    - libgcc-s1
+    - libgssapi-krb5-2
+    - libicu76
+    - liblttng-ust1t64
+    - libpq5
+    - libssl3t64
+    - libstdc++6
+    - libunwind8
+    - libxml2
+    - libxmlsec1t64-openssl
+    - libxslt1.1
+    - python-3.12
+    - tini
+    - trivy=0.71.2-2
+    - tzdata
+    - wget
+  builds:
+    - name: prowler-api
+      work-dir: ${source.dir}/prowler/api
+      environment:
+        POWERSHELL_TELEMETRY_OPTOUT: "1"
+        UV_NO_MANAGED_PYTHON: "true"
+        UV_PROJECT_ENVIRONMENT: /opt/prowler/venv
+        UV_PYTHON_DOWNLOADS: never
+      caches:
+        - path: /root/.cache/uv
+      contents:
+        packages:
+          - bash
+          - build-essential
+          - ca-certificates
+          - coreutils
+          - dash
+          - findutils
+          - git
+          - gzip
+          - libicu76
+          - liblttng-ust1t64
+          - libpq-dev
+          - libtool
+          - libssl-dev
+          - libunwind8
+          - libxml2-dev
+          - libxmlsec1-dev
+          - libxslt1-dev
+          - pkg-config
+          - python-3.12
+          - python-3.12-dev
+          - python3-pip
+          - python3-setuptools
+          - python3-wheel
+          - sed
+          - tar
+          - uv
+        files:
+          - url: git+https://github.com/prowler-cloud/prowler.git#5.36.0
+            checksum: 685d24dfee4616981e017b1745e3b8f2633d499d
+            path: ${source.dir}/prowler
+            spdx:
+              name: prowler-api
+              version: 5.36.0
+              packages:
+                - name: prowler-api
+                  purl: pkg:github/prowler-cloud/prowler@5.36.0#api
+                  license: Apache-2.0
+            uid: 0
+            gid: 0
+          - url: https://github.com/PowerShell/PowerShell/releases/download/v7.5.0/powershell-7.5.0-linux-${POWERSHELL_ARCH}.tar.gz
+            checksum: ${POWERSHELL_CHECKSUM}
+            path: ${source.dir}/powershell.tar.gz
+            spdx:
+              name: powershell
+              version: 7.5.0
+              packages:
+                - name: powershell
+                  purl: pkg:github/PowerShell/PowerShell@v7.5.0
+                  license: MIT
+            uid: 0
+            gid: 0
+          - url: https://github.com/zizmorcore/zizmor/releases/download/v1.24.1/zizmor-${ZIZMOR_ARCH}.tar.gz
+            checksum: ${ZIZMOR_CHECKSUM}
+            path: ${source.dir}/zizmor.tar.gz
+            spdx:
+              name: zizmor
+              version: 1.24.1
+              packages:
+                - name: zizmor
+                  purl: pkg:github/zizmorcore/zizmor@v1.24.1
+                  license: MIT
+            uid: 0
+            gid: 0
+      pipeline:
+        - name: install auxiliary scanners
+          runs: |
+            set -eux -o pipefail
+
+            install -d -m 0755 /opt/microsoft/powershell/7 /usr/local/bin
+            tar -xzf "${source.dir}/powershell.tar.gz" -C /opt/microsoft/powershell/7
+            chmod 0755 /opt/microsoft/powershell/7/pwsh
+            ln -sf /opt/microsoft/powershell/7/pwsh /usr/local/bin/pwsh
+
+            tar -xzf "${source.dir}/zizmor.tar.gz" -C /usr/local/bin zizmor
+            chmod 0755 /usr/local/bin/zizmor
+        - name: install locked Python dependencies
+          privileged: true
+          runs: |
+            set -eux -o pipefail
+
+            uv venv /opt/prowler/venv --python /usr/bin/python3.12
+            uv sync --locked --no-dev --no-install-project
+        - name: install pinned Microsoft 365 PowerShell modules
+          privileged: true
+          runs: |
+            set -eux -o pipefail
+
+            pwsh -NoLogo -NoProfile -NonInteractive -Command \
+              "Set-PSRepository PSGallery -InstallationPolicy Trusted; \
+               Install-Module ExchangeOnlineManagement -RequiredVersion 3.10.1 -Scope AllUsers -Force -AllowClobber; \
+               Install-Module MicrosoftTeams -RequiredVersion 7.9.0 -Scope AllUsers -Force -AllowClobber; \
+               Install-Module MSAL.PS -RequiredVersion 4.37.0.0 -Scope AllUsers -Force -AllowClobber"
+        - name: stage application
+          runs: |
+            set -eux -o pipefail
+
+            install -d -m 0755 /opt/prowler/backend
+            cp -a src/backend/. /opt/prowler/backend/
+            install -m 0755 docker-entrypoint.sh /opt/prowler/docker-entrypoint.sh
+            install -m 0644 pyproject.toml uv.lock /opt/prowler/
+
+            # The locked environment is already materialized, so avoid shipping uv
+            # solely as a process launcher while preserving upstream role behavior.
+            sed -i 's/exec uv run /exec /' /opt/prowler/docker-entrypoint.sh
+            sed -i 's/  uv run /  /' /opt/prowler/docker-entrypoint.sh
+        - name: build checks
+          runs: |
+            set -eux -o pipefail
+
+            /opt/prowler/venv/bin/python -c 'import celery, django, prowler; print(django.get_version())'
+            /opt/prowler/venv/bin/gunicorn --version
+            pwsh -NoLogo -NoProfile -NonInteractive -Command \
+              "Get-Module -ListAvailable ExchangeOnlineManagement,MicrosoftTeams,MSAL.PS | Select-Object -ExpandProperty Name | Sort-Object -Unique"
+            zizmor --version
+        - name: python dependencies sbom
+          uses: sbom@v1
+          with:
+            extra-scanners: python-package-cataloger
+            prefix: prowler-api-venv
+            source: /opt/prowler/venv
+        - name: remove build-only caches and tests
+          runs: |
+            set -eux -o pipefail
+
+            find /opt/prowler/venv /opt/prowler/backend \
+              \( -type d -a \( -name tests -o -name __pycache__ \) \) \
+              -o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+              -exec rm -rf '{}' + || true
+      outputs:
+        - source: /opt/prowler
+          target: /opt/prowler
+          uid: 0
+          gid: 0
+        - source: /opt/microsoft/powershell/7
+          target: /opt/microsoft/powershell/7
+          uid: 0
+          gid: 0
+        - source: /usr/local/share/powershell/Modules
+          target: /usr/local/share/powershell/Modules
+          uid: 0
+          gid: 0
+        - source: /usr/local/bin/pwsh
+          target: /usr/local/bin/pwsh
+          uid: 0
+          gid: 0
+          mode: "0755"
+        - source: /usr/local/bin/zizmor
+          target: /usr/local/bin/zizmor
+          uid: 0
+          gid: 0
+          mode: "0755"
+        - source: /opt/docker/sbom/prowler-api
+          target: /opt/docker/sbom/prowler-api
+          uid: 0
+          gid: 0
+        - source: /opt/docker/sbom/prowler-api-venv
+          target: /opt/docker/sbom/prowler-api-venv
+          uid: 0
+          gid: 0
+        - source: /opt/docker/sbom/powershell
+          target: /opt/docker/sbom/powershell
+          uid: 0
+          gid: 0
+        - source: /opt/docker/sbom/zizmor
+          target: /opt/docker/sbom/zizmor
+          uid: 0
+          gid: 0
+accounts:
+  run-as: nonroot
+  users:
+    - name: nonroot
+      uid: 65532
+      gid: 65532
+  groups:
+    - name: nonroot
+      gid: 65532
+      members:
+        - nonroot
+os-release:
+  name: Docker Hardened Images (Debian)
+  id: debian
+  version-id: "13"
+  version-codename: trixie
+  pretty-name: Docker Hardened Images/Debian GNU/Linux 13 (trixie)
+  home-url: https://docker.com/products/hardened-images/
+  bug-report-url: https://docker.com/support/
+work-dir: /opt/prowler/backend
+environment:
+  DJANGO_BIND_ADDRESS: 0.0.0.0
+  DJANGO_DEBUG: "False"
+  DJANGO_PORT: "8080"
+  DJANGO_SETTINGS_MODULE: config.django.production
+  DJANGO_TMP_OUTPUT_DIRECTORY: /tmp/prowler_api_output
+  DOTNET_CLI_TELEMETRY_OPTOUT: "1"
+  HOME: /home/nonroot
+  PATH: /opt/prowler/venv/bin:/opt/microsoft/powershell/7:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  POWERSHELL_TELEMETRY_OPTOUT: "1"
+  PYTHONDONTWRITEBYTECODE: "1"
+  PYTHONUNBUFFERED: "1"
+  TRIVY_CACHE_DIR: /home/nonroot/.cache/trivy
+paths:
+  - type: directory
+    path: /home/nonroot
+    uid: 65532
+    gid: 65532
+    mode: "0755"
+  - type: directory
+    path: /home/nonroot/.cache/trivy
+    uid: 65532
+    gid: 65532
+    mode: "0755"
+  - type: directory
+    path: /tmp/prowler_api_output
+    uid: 65532
+    gid: 65532
+    mode: "0750"
+  - type: symlink
+    path: /usr/bin/pwsh
+    uid: 0
+    gid: 0
+    source: /opt/microsoft/powershell/7/pwsh
+annotations:
+  org.opencontainers.image.description: A minimal Prowler API, worker, and scheduler image
+  org.opencontainers.image.licenses: Apache-2.0
+entrypoint:
+  - /usr/bin/tini
+  - --
+  - /opt/prowler/docker-entrypoint.sh
+cmd:
+  - prod
+ports:
+  - 8080/tcp

--- a/image/prowler-api/guides.md
+++ b/image/prowler-api/guides.md
@@ -1,0 +1,72 @@
+## How to use this image
+
+Authenticate with `docker login dhi.io` before pulling the public image. Replace `<tag>` with a published 5.36 tag. Prowler App requires separate API, worker, beat, UI, PostgreSQL, and Valkey or Redis services; Neo4j is additionally required for attack paths.
+
+### Runtime roles
+
+The default role starts the production API:
+
+```bash
+docker run --rm -p 8080:8080 \
+  --env-file /secure/path/prowler-api.env \
+  dhi.io/prowler-api:<tag>
+```
+
+Use the same image with a command override for workers and the scheduler:
+
+```bash
+# Celery worker
+docker run --rm --env-file /secure/path/prowler-api.env \
+  dhi.io/prowler-api:<tag> worker
+
+# Celery Beat; run exactly one scheduler replica
+docker run --rm --env-file /secure/path/prowler-api.env \
+  dhi.io/prowler-api:<tag> beat
+```
+
+The image entrypoint accepts `prod`, `worker`, or `beat`. `prod` runs database migrations before starting Gunicorn. Coordinate deployments so only the intended API replicas perform migrations, and run a single `beat` replica to avoid duplicate scheduling.
+
+### Required configuration
+
+Use the upstream Prowler deployment documentation as the source of truth. Common settings include:
+
+| Variable | Purpose |
+| --- | --- |
+| `DJANGO_TOKEN_SIGNING_KEY` / `DJANGO_TOKEN_VERIFYING_KEY` | Asymmetric keys used to sign and verify tokens. Supply as secrets. |
+| `DJANGO_SECRETS_ENCRYPTION_KEY` | Encrypts provider credentials at rest. Supply as a secret. |
+| `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD` | PostgreSQL connectivity. |
+| `VALKEY_HOST`, `VALKEY_PORT`, `VALKEY_DB`, `VALKEY_PASSWORD` | Celery broker connectivity. |
+| `DJANGO_ALLOWED_HOSTS` | Hostnames accepted by Django. Do not use `*` in production. |
+| `DJANGO_PORT` | API listen port; defaults to `8080`. |
+| `DJANGO_WORKERS` | Gunicorn worker count. |
+| `DJANGO_TMP_OUTPUT_DIRECTORY` | Writable report staging directory; defaults to `/tmp/prowler_api_output`. |
+| `NEO4J_URI`, `NEO4J_USER`, `NEO4J_PASSWORD` | Neo4j connectivity for attack paths. |
+
+Do not put credentials in an image, compose file committed to source control, or command history. Use Docker secrets, Kubernetes Secrets, or an external secrets manager.
+
+### Included assessment tools
+
+`trivy`, `zizmor`, and `pwsh` are on `PATH`. Trivy stores its writable cache under `/home/nonroot/.cache/trivy`. Microsoft 365 assessment support includes the ExchangeOnlineManagement 3.10.1, MicrosoftTeams 7.9.0, and MSAL.PS 4.37.0.0 modules.
+
+### Health probes
+
+Use orchestrator HTTP probes rather than adding a shell-based Docker health check. Probe `/health/live` for liveness and `/health/ready` for readiness on port 8080 after migrations complete. Prowler's Helm chart is a useful reference for current probe timings.
+
+## Migration notes
+
+| Item | Upstream image | Docker Hardened Image |
+| --- | --- | --- |
+| Image | `prowlercloud/prowler-api:5.36.0` | `dhi.io/prowler-api:<tag>` |
+| User | Upstream `prowler` uid 1000 | `nonroot` uid/gid 65532 |
+| Entrypoint | `/home/prowler/docker-entrypoint.sh prod` | `tini -- /opt/prowler/docker-entrypoint.sh prod` |
+| Working directory | `/home/prowler/backend` | `/opt/prowler/backend` |
+| Package manager | Build-derived Debian image | No package manager in runtime |
+| Writable data | `/tmp/prowler_api_output` | Same default, owned by uid 65532 |
+
+If a persistent report or cache volume is mounted, ensure uid/gid 65532 can write it. The runtime has only the tools required by Prowler; use Docker Debug for troubleshooting rather than installing packages into a running container.
+
+## Additional resources
+
+- [Prowler documentation](https://docs.prowler.com/)
+- [Prowler App deployment](https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/prowler-app/)
+- [Prowler source](https://github.com/prowler-cloud/prowler)

--- a/image/prowler-api/info.yaml
+++ b/image/prowler-api/info.yaml
@@ -1,0 +1,8 @@
+metadata:
+  display-name: Prowler API
+  short-description: Prowler API provides the backend, scan workers, and scheduler for the Prowler open-source cloud security platform.
+  featured: false
+  home-url: https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/prowler-app/
+  categories:
+    - security
+    - api-management

--- a/image/prowler-api/logo.svg
+++ b/image/prowler-api/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96" fill="none">
+  <rect width="96" height="96" fill="white"/>
+  <path fill="#8CE046" fill-rule="evenodd" clip-rule="evenodd" d="M25 16h28.5a24 24 0 0 1 0 48H41.5v24H25V16Zm16.5 15v18H52a9 9 0 1 0 0-18H41.5Z"/>
+</svg>

--- a/image/prowler-api/overview.md
+++ b/image/prowler-api/overview.md
@@ -1,0 +1,23 @@
+## About Prowler API
+
+Prowler is an open-source cloud security platform that assesses AWS, Azure, Google Cloud, Kubernetes, Microsoft 365, and other environments against security and compliance best practices. The Prowler API is the Django and Django REST Framework backend used by Prowler App. It persists providers, scans, findings, resources, schedules, and compliance results in PostgreSQL and dispatches scan work through Celery.
+
+## About this image
+
+This image packages the Prowler 5.36.0 API and its Celery processes. One immutable image supports all production roles by overriding its command:
+
+- **API** (default): `prod` applies migrations and starts Gunicorn with ASGI workers on port 8080.
+- **Worker**: `worker` processes scans, reports, integrations, compliance, and attack-path jobs.
+- **Scheduler**: `beat` runs Celery Beat with the Django database scheduler.
+
+The runtime includes the functionality expected by upstream Prowler: PowerShell 7.5.0 with pinned Exchange Online, Microsoft Teams, and MSAL modules; Trivy 0.71.2 for image and IaC analysis; and zizmor 1.24.1 for GitHub Actions workflow analysis. It runs as nonroot uid 65532 and contains no package manager or build toolchain.
+
+PostgreSQL, Valkey or Redis, and (when attack-path functionality is enabled) Neo4j are external services and are not bundled in the image. Runtime signing keys, encryption keys, database credentials, cloud credentials, and API tokens must be supplied through a secrets manager or orchestrator.
+
+## About Docker Hardened Images
+
+Docker Hardened Images are built to meet high security and compliance standards. They provide a minimal, continuously maintained foundation, signed provenance, and a complete Software Bill of Materials (SBOM) and VEX metadata.
+
+## Trademarks
+
+Prowler is a trademark of Prowler, Inc. All third-party product names, logos, and trademarks are the property of their respective owners and are used solely for identification. Docker claims no affiliation, sponsorship, or endorsement.

--- a/image/prowler-mcp/config/server.json
+++ b/image/prowler-mcp/config/server.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.prowler-cloud/prowler-mcp",
+  "description": "Prowler MCP server for security findings, scans, compliance, Hub, and documentation.",
+  "repository": {
+    "url": "https://github.com/prowler-cloud/prowler",
+    "source": "github",
+    "subfolder": "mcp_server"
+  },
+  "version": "_VERSION_",
+  "packages": [
+    {
+      "registryType": "oci",
+      "registryBaseUrl": "https://dhi.io",
+      "identifier": "prowler-mcp:_VERSION_@__digest__",
+      "version": "_VERSION_",
+      "transport": { "type": "stdio" },
+      "runtimeArguments": [
+        { "type": "named", "name": "--rm" },
+        { "type": "named", "name": "-i" }
+      ],
+      "environmentVariables": [
+        {
+          "name": "PROWLER_API_KEY",
+          "description": "Prowler API key for authenticated Prowler application tools. Hub and documentation tools do not require it.",
+          "isRequired": false,
+          "isSecret": true
+        },
+        {
+          "name": "API_BASE_URL",
+          "description": "Prowler API v1 base URL. Defaults to https://api.prowler.com/api/v1.",
+          "isRequired": false,
+          "isSecret": false
+        }
+      ]
+    }
+  ]
+}

--- a/image/prowler-mcp/debian-13/5.yaml
+++ b/image/prowler-mcp/debian-13/5.yaml
@@ -1,0 +1,172 @@
+# syntax=dhi.io/build:2-debian13
+
+name: Prowler MCP Server 5.x
+image: dhi.io/prowler-mcp
+variant: runtime
+tags:
+  - "5"
+  - "5.36"
+  - 5.36.0
+  - 5-debian
+  - 5-debian13
+  - 5.36-debian
+  - 5.36-debian13
+  - 5.36.0-debian
+  - 5.36.0-debian13
+platforms:
+  - linux/amd64
+  - linux/arm64
+dates:
+  release: "2026-07-24"
+vars:
+  COMMIT_SHA: 685d24dfee4616981e017b1745e3b8f2633d499d
+  MCP_VERSION: 0.8.0
+  PYTHON_MAJOR_MINOR_VERSION: "3.13"
+  SEMVER_MAJOR_MINOR_VERSION: "5.36"
+  SEMVER_MAJOR_VERSION: "5"
+  SEMVER_VERSION: 5.36.0
+  VERSION: 5.36.0
+contents:
+  repositories:
+    - deb [signed-by=/usr/share/keyrings/dhi-deb-main.gpg] http://dhi.io/deb/debian/main trixie main
+  keyring:
+    - https://dhi.io/keyring/dhi-deb-gpg.D46852F6925E9F71.key
+  packages:
+    - base-files
+    - ca-certificates-bundle
+    - python-3.13
+    - tzdata
+  builds:
+    - name: prowler-mcp
+      work-dir: ${source.dir}/prowler/mcp_server
+      environment:
+        UV_COMPILE_BYTECODE: "1"
+        UV_NO_MANAGED_PYTHON: "true"
+        UV_PROJECT_ENVIRONMENT: /opt/prowler-mcp/venv
+        UV_PYTHON_DOWNLOADS: never
+      caches:
+        - path: /root/.cache/uv
+      contents:
+        packages:
+          - ca-certificates
+          - coreutils
+          - git
+          - python-3.13
+          - python-3.13-dev
+          - python3-pip
+          - python3-setuptools
+          - python3-wheel
+          - uv
+        files:
+          - url: git+https://github.com/prowler-cloud/prowler.git#5.36.0
+            checksum: 685d24dfee4616981e017b1745e3b8f2633d499d
+            path: ${source.dir}/prowler
+            spdx:
+              name: prowler-mcp
+              version: 5.36.0
+              packages:
+                - name: prowler-mcp
+                  purl: pkg:github/prowler-cloud/prowler@5.36.0#mcp_server
+                  license: Apache-2.0
+            uid: 0
+            gid: 0
+      pipeline:
+        - name: install locked Python application
+          privileged: true
+          runs: |
+            set -eux -o pipefail
+
+            uv venv /opt/prowler-mcp/venv --python /usr/bin/python3.13
+            uv sync --locked --no-dev --no-editable
+        - name: build checks
+          runs: |
+            set -eux -o pipefail
+
+            /opt/prowler-mcp/venv/bin/python -c \
+              'from prowler_mcp_server import __version__; from prowler_mcp_server.server import app; assert __version__ == "0.8.0"; print(__version__)'
+            /opt/prowler-mcp/venv/bin/prowler-mcp --help
+        - name: python dependencies sbom
+          uses: sbom@v1
+          with:
+            extra-scanners: python-package-cataloger
+            prefix: prowler-mcp-venv
+            source: /opt/prowler-mcp/venv
+        - name: remove Python caches
+          runs: |
+            set -eux -o pipefail
+
+            find /opt/prowler-mcp/venv \
+              \( -type d -a -name __pycache__ \) \
+              -o \( -type f -a \( -name '*.pyc' -o -name '*.pyo' \) \) \
+              -exec rm -rf '{}' + || true
+      outputs:
+        - source: /opt/prowler-mcp/venv
+          target: /opt/prowler-mcp/venv
+          uid: 0
+          gid: 0
+        - source: /opt/docker/sbom/prowler-mcp
+          target: /opt/docker/sbom/prowler-mcp
+          uid: 0
+          gid: 0
+        - source: /opt/docker/sbom/prowler-mcp-venv
+          target: /opt/docker/sbom/prowler-mcp-venv
+          uid: 0
+          gid: 0
+    - name: server.json
+      contents:
+        packages:
+          - bash
+          - sed
+      pipeline:
+        - runs: |
+            set -eux -o pipefail
+
+            sed -i "s/_VERSION_/5.36.0/g" "${source.dir}/config/server.json"
+      paths:
+        - type: file
+          path: ${source.dir}/config/server.json
+          uid: 0
+          gid: 0
+          source: image/prowler-mcp/config/server.json
+      attestations:
+        - predicate-type: https://modelcontextprotocol.io/server.json/v1
+          source: ${source.dir}/config/server.json
+accounts:
+  run-as: nonroot
+  users:
+    - name: nonroot
+      uid: 65532
+      gid: 65532
+  groups:
+    - name: nonroot
+      gid: 65532
+      members:
+        - nonroot
+os-release:
+  name: Docker Hardened Images (Debian)
+  id: debian
+  version-id: "13"
+  version-codename: trixie
+  pretty-name: Docker Hardened Images/Debian GNU/Linux 13 (trixie)
+  home-url: https://docker.com/products/hardened-images/
+  bug-report-url: https://docker.com/support/
+environment:
+  HOME: /home/nonroot
+  PATH: /opt/prowler-mcp/venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  PYTHONDONTWRITEBYTECODE: "1"
+  PYTHONUNBUFFERED: "1"
+paths:
+  - type: directory
+    path: /home/nonroot
+    uid: 65532
+    gid: 65532
+    mode: "0755"
+annotations:
+  org.opencontainers.image.description: Prowler MCP Server for security findings, scans, compliance, Hub, and documentation
+  org.opencontainers.image.licenses: Apache-2.0
+labels:
+  io.modelcontextprotocol.server.name: io.github.prowler-cloud/prowler-mcp
+entrypoint:
+  - /opt/prowler-mcp/venv/bin/prowler-mcp
+ports:
+  - 8000/tcp

--- a/image/prowler-mcp/guides.md
+++ b/image/prowler-mcp/guides.md
@@ -1,0 +1,79 @@
+## How to use this image
+
+Authenticate with `docker login dhi.io` before pulling the image.
+
+### Stdio mode (default)
+
+Run with an interactive stdin so an MCP client can exchange protocol messages:
+
+```bash
+docker run --rm -i \
+  -e PROWLER_API_KEY \
+  -e API_BASE_URL=https://api.prowler.com/api/v1 \
+  dhi.io/prowler-mcp:<tag>
+```
+
+Set `PROWLER_API_KEY` in the parent environment from a secrets manager; do not put its value in the command or configuration file. The key is optional when only Prowler Hub and documentation tools are used.
+
+Example MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "prowler": {
+      "command": "docker",
+      "args": ["run", "--rm", "-i", "-e", "PROWLER_API_KEY", "dhi.io/prowler-mcp:<tag>"]
+    }
+  }
+}
+```
+
+### Streamable HTTP mode
+
+Override the CLI arguments and bind to all container interfaces:
+
+```bash
+docker run --rm -p 8000:8000 \
+  dhi.io/prowler-mcp:<tag> \
+  --transport http --host 0.0.0.0 --port 8000
+```
+
+The MCP endpoint is available at `http://localhost:8000/mcp` and health status at `http://localhost:8000/health`. HTTP clients authenticate Prowler application tools with `Authorization: Bearer <API-key-or-JWT>`. Terminate TLS at a trusted reverse proxy, restrict network access, and never log authorization headers.
+
+### Environment variables
+
+| Variable | Purpose | Required |
+| --- | --- | --- |
+| `PROWLER_API_KEY` | API key used by Prowler application tools in stdio mode. Treat as secret. | For authenticated stdio tools |
+| `PROWLER_APP_API_KEY` | Deprecated compatibility alias for `PROWLER_API_KEY`. | No |
+| `API_BASE_URL` | Prowler API v1 base URL; defaults to `https://api.prowler.com/api/v1`. | No |
+| `PROWLER_MCP_TRANSPORT_MODE` | Alternative to `--transport`; accepts `stdio` or `http`. | No |
+
+CLI flags take precedence when supplied. The image exposes port 8000 as documentation; stdio mode does not open a network listener.
+
+## Migration notes
+
+| Item | Upstream image | Docker Hardened Image |
+| --- | --- | --- |
+| Image | `prowlercloud/prowler-mcp:5.36.0` | `dhi.io/prowler-mcp:<tag>` |
+| User | Upstream `prowler` uid 1001 | `nonroot` uid/gid 65532 |
+| Default | Entrypoint wrapper, `main` command | Direct `prowler-mcp`, native stdio default |
+| HTTP | `--transport http --host 0.0.0.0 --port 8000` | Same CLI arguments |
+| Runtime | Alpine Python | Minimal Debian 13 Python |
+
+The runtime has no shell or package manager. Use Docker Debug for troubleshooting rather than modifying the running image.
+
+## Security best practices
+
+- Scope API keys to only the tenants and operations the MCP client needs.
+- Prefer read-only access where possible and rotate keys regularly.
+- Keep stdio containers ephemeral with `--rm` and do not persist their environment.
+- Put HTTP mode behind TLS, authentication-aware ingress, and network policy.
+- Treat MCP tool output as potentially sensitive security data.
+
+## Additional resources
+
+- [Prowler MCP overview](https://docs.prowler.com/getting-started/products/prowler-mcp)
+- [Prowler MCP installation](https://docs.prowler.com/getting-started/installation/prowler-mcp)
+- [Prowler MCP tools](https://docs.prowler.com/getting-started/basic-usage/prowler-mcp-tools)
+- [Model Context Protocol](https://modelcontextprotocol.io/)

--- a/image/prowler-mcp/info.yaml
+++ b/image/prowler-mcp/info.yaml
@@ -1,0 +1,9 @@
+metadata:
+  display-name: Prowler MCP Server
+  short-description: The official Prowler MCP Server gives AI assistants access to Prowler findings, scans, compliance data, Hub content, and documentation.
+  featured: false
+  home-url: https://docs.prowler.com/getting-started/products/prowler-mcp
+  categories:
+    - security
+    - developer-tools
+    - machine-learning-and-ai

--- a/image/prowler-mcp/logo.svg
+++ b/image/prowler-mcp/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96" fill="none">
+  <rect width="96" height="96" fill="white"/>
+  <path fill="#8CE046" fill-rule="evenodd" clip-rule="evenodd" d="M25 16h28.5a24 24 0 0 1 0 48H41.5v24H25V16Zm16.5 15v18H52a9 9 0 1 0 0-18H41.5Z"/>
+</svg>

--- a/image/prowler-mcp/overview.md
+++ b/image/prowler-mcp/overview.md
@@ -1,0 +1,17 @@
+## About Prowler MCP Server
+
+The official Prowler MCP Server connects AI assistants and agents to the Prowler ecosystem through the Model Context Protocol. Its namespaced tools can query and manage Prowler findings, finding groups, providers, scans, resources, muting, compliance data, and attack paths. It also exposes unauthenticated search tools for Prowler Hub and the official Prowler documentation.
+
+## About this image
+
+This image packages the MCP server released with Prowler 5.36.0 (MCP package 0.8.0) from its locked uv environment. It runs stdio transport by default for desktop and editor MCP clients. The same executable supports streamable HTTP transport with `--transport http`; HTTP mode listens on port 8000 when configured with `--host 0.0.0.0 --port 8000`.
+
+The runtime is a minimal Debian 13 Python image and runs as nonroot uid 65532. No credentials are embedded. Prowler Hub and documentation tools work without authentication; Prowler application tools require an API key in stdio mode or a bearer token supplied by each HTTP client.
+
+## About Docker Hardened Images
+
+Docker Hardened Images are built to meet high security and compliance standards. They provide a minimal, continuously maintained foundation, signed provenance, and a complete Software Bill of Materials (SBOM) and VEX metadata.
+
+## Trademarks
+
+Prowler is a trademark of Prowler, Inc. All third-party product names, logos, and trademarks are the property of their respective owners and are used solely for identification. Docker claims no affiliation, sponsorship, or endorsement.

--- a/image/prowler-ui/debian-13/5.yaml
+++ b/image/prowler-ui/debian-13/5.yaml
@@ -1,0 +1,160 @@
+# syntax=dhi.io/build:2-debian13
+
+name: Prowler UI 5.x
+image: dhi.io/prowler-ui
+variant: runtime
+tags:
+  - "5"
+  - "5.36"
+  - 5.36.0
+  - 5-debian
+  - 5-debian13
+  - 5.36-debian
+  - 5.36-debian13
+  - 5.36.0-debian
+  - 5.36.0-debian13
+platforms:
+  - linux/amd64
+  - linux/arm64
+dates:
+  release: "2026-07-24"
+vars:
+  COMMIT_SHA: 685d24dfee4616981e017b1745e3b8f2633d499d
+  NODE_MAJOR_VERSION: "24"
+  PNPM_VERSION: 11.1.3
+  SEMVER_MAJOR_MINOR_VERSION: "5.36"
+  SEMVER_MAJOR_VERSION: "5"
+  SEMVER_VERSION: 5.36.0
+  VERSION: 5.36.0
+contents:
+  repositories:
+    - deb [signed-by=/usr/share/keyrings/dhi-deb-main.gpg] http://dhi.io/deb/debian/main trixie main
+  keyring:
+    - https://dhi.io/keyring/dhi-deb-gpg.D46852F6925E9F71.key
+  packages:
+    - base-files
+    - ca-certificates
+    - ca-certificates-bundle
+    - dash
+    - dumb-init
+    - libc6
+    - libgomp1
+    - libstdc++6
+    - netbase
+    - nodejs-24
+    - tzdata
+  builds:
+    - name: prowler-ui
+      work-dir: ${source.dir}/prowler/ui
+      environment:
+        NEXT_PUBLIC_PROWLER_RELEASE_VERSION: 5.36.0
+        NEXT_TELEMETRY_DISABLED: "1"
+        NODE_OPTIONS: --max-old-space-size=4096
+        PNPM_HOME: /pnpm
+      caches:
+        - path: /pnpm/store
+        - path: /root/.cache
+      contents:
+        packages:
+          - bash
+          - ca-certificates
+          - coreutils
+          - findutils
+          - git
+          - node-corepack
+          - nodejs-24
+          - sed
+        files:
+          - url: git+https://github.com/prowler-cloud/prowler.git#5.36.0
+            checksum: 685d24dfee4616981e017b1745e3b8f2633d499d
+            path: ${source.dir}/prowler
+            spdx:
+              name: prowler-ui
+              version: 5.36.0
+              packages:
+                - name: prowler-ui
+                  purl: pkg:github/prowler-cloud/prowler@5.36.0#ui
+                  license: Apache-2.0
+            uid: 0
+            gid: 0
+      pipeline:
+        - name: install locked dependencies
+          privileged: true
+          runs: |
+            set -eux -o pipefail
+
+            corepack enable
+            corepack install
+            pnpm install --frozen-lockfile
+        - name: type check and build standalone application
+          privileged: true
+          runs: |
+            set -eux -o pipefail
+
+            pnpm run typecheck
+            unset CI
+            NODE_ENV=production pnpm run build
+            test -f .next/standalone/server.js
+        - name: stage standalone application
+          runs: |
+            set -eux -o pipefail
+
+            install -d -m 0755 "${target.dir}/app/.next"
+            cp -a .next/standalone/. "${target.dir}/app/"
+            cp -a .next/static "${target.dir}/app/.next/static"
+            cp -a public "${target.dir}/app/public"
+        - name: javascript dependencies sbom
+          uses: sbom@v1
+          with:
+            extra-scanners: javascript-package-cataloger
+            prefix: prowler-ui-node
+            source: ${source.dir}/prowler/ui/node_modules
+      outputs:
+        - source: ${target.dir}/app
+          target: /app
+          uid: 65532
+          gid: 65532
+        - source: /opt/docker/sbom/prowler-ui
+          target: /opt/docker/sbom/prowler-ui
+          uid: 0
+          gid: 0
+        - source: /opt/docker/sbom/prowler-ui-node
+          target: /opt/docker/sbom/prowler-ui-node
+          uid: 0
+          gid: 0
+accounts:
+  run-as: nonroot
+  users:
+    - name: nonroot
+      uid: 65532
+      gid: 65532
+  groups:
+    - name: nonroot
+      gid: 65532
+      members:
+        - nonroot
+os-release:
+  name: Docker Hardened Images (Debian)
+  id: debian
+  version-id: "13"
+  version-codename: trixie
+  pretty-name: Docker Hardened Images/Debian GNU/Linux 13 (trixie)
+  home-url: https://docker.com/products/hardened-images/
+  bug-report-url: https://docker.com/support/
+work-dir: /app
+environment:
+  HOSTNAME: 0.0.0.0
+  NEXT_TELEMETRY_DISABLED: "1"
+  NODE_ENV: production
+  PORT: "3000"
+annotations:
+  org.opencontainers.image.description: A minimal Prowler web UI image
+  org.opencontainers.image.licenses: Apache-2.0
+entrypoint:
+  - /usr/bin/dumb-init
+  - --
+cmd:
+  - node
+  - server.js
+ports:
+  - 3000/tcp

--- a/image/prowler-ui/guides.md
+++ b/image/prowler-ui/guides.md
@@ -1,0 +1,60 @@
+## How to use this image
+
+Authenticate with `docker login dhi.io` before pulling the image. Prowler UI requires a reachable Prowler API.
+
+```bash
+# Export AUTH_SECRET from a secrets manager or secure shell session first.
+docker run --rm -p 3000:3000 \
+  -e UI_API_BASE_URL=https://prowler-api.example.com/api/v1 \
+  -e AUTH_URL=https://prowler.example.com \
+  -e AUTH_SECRET \
+  dhi.io/prowler-ui:<tag>
+```
+
+Set `AUTH_SECRET` in the parent environment from your deployment platform's secret store. Do not put the secret value in source control, the image, or command-line arguments.
+
+### Runtime configuration
+
+| Variable | Purpose |
+| --- | --- |
+| `UI_API_BASE_URL` | Required Prowler API v1 base URL. |
+| `AUTH_URL` | Required public URL of this UI deployment. |
+| `AUTH_SECRET` | Required random authentication secret; always inject securely. |
+| `UI_API_DOCS_URL` | Optional API documentation URL. |
+| `UI_CLOUD_ENABLED` | Set to `true` only for Prowler Cloud deployments. |
+| `UI_SENTRY_ENABLED`, `UI_SENTRY_DSN`, `UI_SENTRY_ENVIRONMENT` | Optional Sentry integration. |
+| `UI_GOOGLE_TAG_MANAGER_ENABLED`, `UI_GOOGLE_TAG_MANAGER_ID` | Optional Google Tag Manager integration. |
+| `PORT` | Internal listen port; defaults to `3000`. |
+| `HOSTNAME` | Listen address; defaults to `0.0.0.0`. |
+
+The enabled integration flags are gates: when a gate is `true`, its corresponding configuration is required. Do not provide telemetry credentials unless the integration is intentionally enabled.
+
+### Health probes
+
+Probe `/api/health` on port 3000. The image does not include `curl`; use the orchestrator's HTTP probe support.
+
+```yaml
+livenessProbe:
+  httpGet: { path: /api/health, port: 3000 }
+readinessProbe:
+  httpGet: { path: /api/health, port: 3000 }
+```
+
+## Migration notes
+
+| Item | Upstream image | Docker Hardened Image |
+| --- | --- | --- |
+| Image | `prowlercloud/prowler-ui:5.36.0` | `dhi.io/prowler-ui:<tag>` |
+| Runtime | Alpine-based Node image | Minimal Debian 13 Node.js 24 runtime |
+| User | `nextjs` uid 1001 | `nonroot` uid/gid 65532 |
+| Command | `node server.js` | `dumb-init -- node server.js` |
+| Port | 3000 | 3000 |
+| Build output | Next.js standalone | Next.js standalone |
+
+The runtime has no shell or package manager. Use Docker Debug for troubleshooting. If mounting files beneath `/app`, ensure they are readable by uid 65532 and do not hide the standalone server files.
+
+## Additional resources
+
+- [Prowler documentation](https://docs.prowler.com/)
+- [Prowler App deployment](https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/prowler-app/)
+- [Prowler source](https://github.com/prowler-cloud/prowler)

--- a/image/prowler-ui/info.yaml
+++ b/image/prowler-ui/info.yaml
@@ -1,0 +1,8 @@
+metadata:
+  display-name: Prowler UI
+  short-description: Prowler UI is the Next.js web interface for exploring cloud security findings, resources, scans, and compliance results.
+  featured: false
+  home-url: https://docs.prowler.com/projects/prowler-open-source/en/latest/tutorials/prowler-app/
+  categories:
+    - security
+    - monitoring-and-observability

--- a/image/prowler-ui/logo.svg
+++ b/image/prowler-ui/logo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96" fill="none">
+  <rect width="96" height="96" fill="white"/>
+  <path fill="#8CE046" fill-rule="evenodd" clip-rule="evenodd" d="M25 16h28.5a24 24 0 0 1 0 48H41.5v24H25V16Zm16.5 15v18H52a9 9 0 1 0 0-18H41.5Z"/>
+</svg>

--- a/image/prowler-ui/overview.md
+++ b/image/prowler-ui/overview.md
@@ -1,0 +1,17 @@
+## About Prowler UI
+
+Prowler UI is the web interface for Prowler App. It presents cloud security findings, resource inventory, provider and scan management, compliance results, attack paths, integrations, and Lighthouse AI workflows through a Next.js application.
+
+## About this image
+
+This image builds Prowler UI 5.36.0 with the upstream pnpm lockfile and packages the Next.js standalone server output. The runtime contains Node.js 24 and only the files traced by Next.js, static assets, and public assets. It listens on port 3000 as nonroot uid 65532.
+
+Runtime configuration is read when `node server.js` starts rather than being embedded at build time. This allows the same immutable image to be promoted across environments. The Prowler API and an authentication secret must be supplied by the deployment.
+
+## About Docker Hardened Images
+
+Docker Hardened Images are built to meet high security and compliance standards. They provide a minimal, continuously maintained foundation, signed provenance, and a complete Software Bill of Materials (SBOM) and VEX metadata.
+
+## Trademarks
+
+Prowler is a trademark of Prowler, Inc. All third-party product names, logos, and trademarks are the property of their respective owners and are used solely for identification. Docker claims no affiliation, sponsorship, or endorsement.


### PR DESCRIPTION
## Description

Adds Docker Hardened Image definitions for the Prowler 5.36.0 application family: API, UI, and MCP server.

## Type of Change

- [x] New image
- [ ] New Helm chart
- [ ] New package
- [ ] Documentation improvement or correction
- [ ] Example configuration or use case
- [ ] Community tooling or script
- [ ] Website or catalog enhancement
- [ ] Bug fix
- [ ] Other (please describe):

## Related Issues

Fixes #494

## Changes Made

- Add Debian 13 non-root runtime definitions for `prowler-api`, `prowler-ui`, and `prowler-mcp` at Prowler 5.36.0.
- Build from the immutable upstream release and locked Python/pnpm dependency sets, including API scanner support, Next.js standalone output, and MCP stdio/HTTP transports.
- Add catalog metadata, guides, overviews, logos, and an MCP `server.json` attestation.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

Local validation performed:
- Parsed all new YAML with `yq`.
- Validated all three build specs with `check-jsonschema==0.35.0` against `.spec.json`.
- Validated `server.json` against the official MCP schema.
- Validated JSON and SVG syntax, whitespace, source commit, artifact checksums, and pinned PowerShell module availability.
- Attempted full DHI `docker buildx build`; local Docker Desktop and both builders returned `EOF`, including after a bounded restart, so full image builds could not complete in this environment.

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] My changes follow the repository's style and conventions
- [x] I have updated documentation as needed
- [x] My commit messages are clear and descriptive

---

> **By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
