### PR TITLE
dozerdb: add hardened image

### DIFF
--- a/image/dozerdb/config/neo4j-plugins.json
+++ b/image/dozerdb/config/neo4j-plugins.json
@@ -1,0 +1,54 @@
+{
+  "apoc-extended": {
+    "versions": "https://neo4j-contrib.github.io/neo4j-apoc-procedures/versions.json",
+    "properties": {
+      "dbms.security.procedures.unrestricted": "apoc.*"
+    }
+  },
+  "apoc": {
+    "location": "/var/lib/neo4j/labs/apoc-*-core.jar",
+    "versions": "https://neo4j.github.io/apoc/versions.json",
+    "properties": {
+      "dbms.security.procedures.unrestricted": "apoc.*"
+    }
+  },
+  "graph-data-science": {
+    "versions": "https://dist.dozerdb.org/plugins/open-gds/versions.json",
+    "location": "/var/lib/neo4j/labs/open-gds-*.jar",
+    "properties": {
+      "dbms.security.procedures.unrestricted": "gds.*"
+    }
+  },
+  "open-gds": {
+    "versions": "https://dist.dozerdb.org/plugins/open-gds/versions.json",
+    "location": "/var/lib/neo4j/labs/open-gds-*.jar",
+    "properties": {
+      "dbms.security.procedures.unrestricted": "gds.*"
+    }
+  },
+  "n10s": {
+    "versions": "https://neo4j-labs.github.io/neosemantics/versions.json",
+    "properties": {
+      "dbms.security.procedures.unrestricted": "semantics.*"
+    }
+  },
+  "genai": {
+    "location": "/var/lib/neo4j/products/neo4j-genai-plugin-*.jar",
+    "properties": {
+      "dbms.security.procedures.unrestricted": "genai.*"
+    }
+  },
+  "fleet-management": {
+    "location": "/var/lib/neo4j/products/neo4j-fleet-management-*.jar",
+    "properties": {
+      "dbms.security.procedures.unrestricted": "fleetManagement.*",
+      "dbms.security.procedures.allowlist": "fleetManagement.*"
+    }
+  },
+  "_testing": {
+    "versions": "http://host.testcontainers.internal:3000/versions.json",
+    "properties": {
+      "dbms.security.procedures.unrestricted": "com.neo4j.docker.neo4jserver.plugins.*"
+    }
+  }
+}

--- a/image/dozerdb/debian-13/5-dev.yaml
+++ b/image/dozerdb/debian-13/5-dev.yaml
@@ -1,0 +1,239 @@
+# syntax=dhi.io/build:2-debian13
+
+name: DozerDB 5.26.27.0 (dev)
+image: dhi.io/dozerdb
+variant: dev
+tags:
+  - 5-dev
+  - 5.26-dev
+  - 5.26.27-dev
+  - 5.26.27.0-dev
+  - 5-debian-dev
+  - 5-debian13-dev
+  - 5.26-debian-dev
+  - 5.26-debian13-dev
+  - 5.26.27-debian-dev
+  - 5.26.27-debian13-dev
+  - 5.26.27.0-debian-dev
+  - 5.26.27.0-debian13-dev
+platforms:
+  - linux/amd64
+  - linux/arm64
+dates:
+  release: "2026-06-12"
+vars:
+  DOCKER_NEO4J_PUBLISH_COMMIT_SHA: 3e584bcdacb6b8f64729dd4a4850f4b06a605238
+  DOZERDB_VERSION: 5.26.27.0
+  GOSU_REFERENCE: dhi/pkg-gosu:1.19-debian13@sha256:fc41f434294f5397fed2c3a2437604e46e54217b53f25425cc734e54a63e9a91
+  NEO4J_VERSION: 5.26.27
+  SEMVER_MAJOR_MINOR_VERSION: "5.26"
+  SEMVER_MAJOR_VERSION: "5"
+  SEMVER_VERSION: 5.26.27.0
+  VERSION: 5.26.27.0
+contents:
+  repositories:
+    - deb [signed-by=/usr/share/keyrings/dhi-deb-main.gpg] http://dhi.io/deb/debian/main trixie main
+  keyring:
+    - https://dhi.io/keyring/dhi-deb-gpg.D46852F6925E9F71.key
+  packages:
+    - '!gawk'
+    - '!libelogind0'
+    - '!mawk'
+    - '!original-awk'
+    - apt
+    - base-files
+    - bash
+    - ca-certificates
+    - coreutils
+    - diffutils
+    - dpkg
+    - eclipse-temurin-21-jre
+    - eclipse-temurin-21-jre-oci-config
+    - findutils
+    - grep
+    - jq
+    - libc-bin
+    - mawk
+    - perl-base
+    - procps
+    - sed
+    - tini
+    - util-linux
+    - wget
+  builds:
+    - name: dozerdb
+      contents:
+        packages:
+          - bash
+          - coreutils
+          - eclipse-temurin-21-jre
+          - findutils
+          - grep
+          - gzip
+          - jq
+          - sed
+          - tar
+        files:
+          # DozerDB does not publish a source tag or commit that maps exactly to this release.
+          # This checksum-pinned upstream distribution is therefore the reproducibility boundary.
+          - url: https://dist.dozerdb.org/dozerdb-5.26.27.0-unix.tar.gz
+            checksum: sha256:19888fc3f658fe69640ac3f90ad9c1177a50ae5f03fbf6c1835438ffe770264e
+            path: ${source.dir}/dozerdb-5.26.27.0-unix.tar.gz
+            spdx:
+              name: dozerdb
+              version: 5.26.27.0
+              packages:
+                - name: dozerdb
+                  purl: pkg:generic/dozerdb@5.26.27.0
+                  license: GPL-3.0
+            uid: 0
+            gid: 0
+          - url: git+https://github.com/neo4j/docker-neo4j-publish.git#3e584bcdacb6b8f64729dd4a4850f4b06a605238
+            checksum: 3e584bcdacb6b8f64729dd4a4850f4b06a605238
+            path: ${source.dir}/docker-neo4j-publish
+            spdx:
+              name: docker-neo4j-publish
+              version: 3e584bcdacb6b8f64729dd4a4850f4b06a605238
+              packages:
+                - name: docker-neo4j-publish
+                  purl: pkg:github/neo4j/docker-neo4j-publish@3e584bcdacb6b8f64729dd4a4850f4b06a605238
+                  license: Apache-2.0
+            uid: 0
+            gid: 0
+      pipeline:
+        - name: install distribution and startup scripts
+          runs: |
+            set -eux -o pipefail
+
+            mkdir -p ${target.dir}/var/lib/neo4j
+            tar -xzf ${source.dir}/dozerdb-5.26.27.0-unix.tar.gz \
+              -C ${target.dir}/var/lib/neo4j \
+              --strip-components=1
+
+            cp -R \
+              ${source.dir}/docker-neo4j-publish/5.26.27/trixie/community/local-package \
+              ${target.dir}/startup
+            install -m 0644 ${source.dir}/neo4j-plugins.json \
+              ${target.dir}/startup/neo4j-plugins.json
+
+            # gosu is the hardened replacement for the upstream su-exec helper.
+            sed -i 's/su-exec/gosu/g' ${target.dir}/startup/docker-entrypoint.sh
+            mv ${target.dir}/startup/neo4j-admin-report.sh \
+              ${target.dir}/var/lib/neo4j/bin/neo4j-admin-report
+
+            sed -i 's/Package Type:.*/Package Type: docker trixie/' \
+              ${target.dir}/var/lib/neo4j/packaging_info
+            chmod 0755 ${target.dir}/startup/*.sh
+            chmod 0755 ${target.dir}/var/lib/neo4j/bin/*
+        - name: verify distribution
+          runs: |
+            set -eux -o pipefail
+
+            test -f ${target.dir}/var/lib/neo4j/lib/dozerdb-core-5.26.27-1.1.0.jar
+            test -f ${target.dir}/var/lib/neo4j/lib/dozerdb-browser-5.26.27.0.jar
+            test -d ${target.dir}/var/lib/neo4j/data
+            test -d ${target.dir}/var/lib/neo4j/logs
+            test -d ${target.dir}/var/lib/neo4j/plugins
+            test -d ${target.dir}/var/lib/neo4j/import
+
+            bash -n ${target.dir}/startup/docker-entrypoint.sh
+            jq -e '
+              has("apoc") and
+              has("apoc-extended") and
+              has("graph-data-science") and
+              has("open-gds") and
+              has("n10s") and
+              has("genai")
+            ' ${target.dir}/startup/neo4j-plugins.json
+
+            version_output="$(JAVA_HOME=/usr/lib/jvm/temurin-21 ${target.dir}/var/lib/neo4j/bin/neo4j version)"
+            echo "${version_output}"
+            echo "${version_output}" | grep -F '5.26.27'
+            java -version 2>&1 | grep -F '21.'
+      paths:
+        - type: file
+          path: ${source.dir}/neo4j-plugins.json
+          uid: 0
+          gid: 0
+          source: image/dozerdb/config/neo4j-plugins.json
+      outputs:
+        - source: ${target.dir}/var/lib/neo4j
+          target: /var/lib/neo4j
+          uid: 7474
+          gid: 7474
+          mode: "0744"
+        - source: ${target.dir}/startup
+          target: /startup
+          uid: 0
+          gid: 0
+        - source: ${target.dir}/startup/docker-entrypoint.sh
+          target: /usr/local/bin/docker-entrypoint.sh
+          uid: 0
+          gid: 0
+          mode: "0755"
+        - source: /opt/docker/sbom/dozerdb
+          target: /opt/docker/sbom/dozerdb
+          uid: 0
+          gid: 0
+  artifacts:
+    - name: ${GOSU_REFERENCE}
+      includes:
+        - opt/docker/sbom/gosu
+        - usr/local/sbin/gosu
+      uid: 0
+      gid: 0
+accounts:
+  root: true
+  run-as: root
+  users:
+    - name: neo4j
+      uid: 7474
+      gid: 7474
+    - name: _apt
+      uid: 42
+      gid: 65532
+  groups:
+    - name: neo4j
+      gid: 7474
+      members:
+        - neo4j
+os-release:
+  name: Docker Hardened Images (Debian)
+  id: debian
+  version-id: "13"
+  version-codename: trixie
+  pretty-name: Docker Hardened Images/Debian GNU/Linux 13 (trixie)
+  home-url: https://docker.com/products/hardened-images/
+  bug-report-url: https://docker.com/support/
+environment:
+  DEBIAN_FRONTEND: noninteractive
+  JAVA_HOME: /usr/lib/jvm/temurin-21
+  LANG: C.UTF-8
+  NEO4J_EDITION: community
+  NEO4J_HOME: /var/lib/neo4j
+  PATH: /usr/local/sbin:/var/lib/neo4j/bin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+paths:
+  - type: symlink
+    path: /data
+    uid: 7474
+    gid: 7474
+    source: /var/lib/neo4j/data
+  - type: symlink
+    path: /logs
+    uid: 7474
+    gid: 7474
+    source: /var/lib/neo4j/logs
+annotations:
+  org.opencontainers.image.description: A minimal DozerDB image
+  org.opencontainers.image.licenses: GPL-3.0
+entrypoint:
+  - /usr/bin/tini
+  - -g
+  - --
+  - /startup/docker-entrypoint.sh
+cmd:
+  - neo4j
+ports:
+  - 7473/tcp
+  - 7474/tcp
+  - 7687/tcp

--- a/image/dozerdb/debian-13/5.yaml
+++ b/image/dozerdb/debian-13/5.yaml
@@ -1,0 +1,228 @@
+# syntax=dhi.io/build:2-debian13
+
+name: DozerDB 5.26.27.0
+image: dhi.io/dozerdb
+variant: runtime
+tags:
+  - "5"
+  - "5.26"
+  - 5.26.27
+  - 5.26.27.0
+  - 5-debian
+  - 5-debian13
+  - 5.26-debian
+  - 5.26-debian13
+  - 5.26.27-debian
+  - 5.26.27-debian13
+  - 5.26.27.0-debian
+  - 5.26.27.0-debian13
+platforms:
+  - linux/amd64
+  - linux/arm64
+dates:
+  release: "2026-06-12"
+vars:
+  DOCKER_NEO4J_PUBLISH_COMMIT_SHA: 3e584bcdacb6b8f64729dd4a4850f4b06a605238
+  DOZERDB_VERSION: 5.26.27.0
+  GOSU_REFERENCE: dhi/pkg-gosu:1.19-debian13@sha256:fc41f434294f5397fed2c3a2437604e46e54217b53f25425cc734e54a63e9a91
+  NEO4J_VERSION: 5.26.27
+  SEMVER_MAJOR_MINOR_VERSION: "5.26"
+  SEMVER_MAJOR_VERSION: "5"
+  SEMVER_VERSION: 5.26.27.0
+  VERSION: 5.26.27.0
+contents:
+  repositories:
+    - deb [signed-by=/usr/share/keyrings/dhi-deb-main.gpg] http://dhi.io/deb/debian/main trixie main
+  keyring:
+    - https://dhi.io/keyring/dhi-deb-gpg.D46852F6925E9F71.key
+  packages:
+    - '!gawk'
+    - '!libelogind0'
+    - '!mawk'
+    - '!original-awk'
+    - base-files
+    - bash
+    - ca-certificates
+    - coreutils
+    - eclipse-temurin-21-jre
+    - eclipse-temurin-21-jre-oci-config
+    - findutils
+    - grep
+    - jq
+    - mawk
+    - procps
+    - sed
+    - tini
+    - wget
+  builds:
+    - name: dozerdb
+      contents:
+        packages:
+          - bash
+          - coreutils
+          - eclipse-temurin-21-jre
+          - findutils
+          - grep
+          - gzip
+          - jq
+          - sed
+          - tar
+        files:
+          # DozerDB does not publish a source tag or commit that maps exactly to this release.
+          # This checksum-pinned upstream distribution is therefore the reproducibility boundary.
+          - url: https://dist.dozerdb.org/dozerdb-5.26.27.0-unix.tar.gz
+            checksum: sha256:19888fc3f658fe69640ac3f90ad9c1177a50ae5f03fbf6c1835438ffe770264e
+            path: ${source.dir}/dozerdb-5.26.27.0-unix.tar.gz
+            spdx:
+              name: dozerdb
+              version: 5.26.27.0
+              packages:
+                - name: dozerdb
+                  purl: pkg:generic/dozerdb@5.26.27.0
+                  license: GPL-3.0
+            uid: 0
+            gid: 0
+          - url: git+https://github.com/neo4j/docker-neo4j-publish.git#3e584bcdacb6b8f64729dd4a4850f4b06a605238
+            checksum: 3e584bcdacb6b8f64729dd4a4850f4b06a605238
+            path: ${source.dir}/docker-neo4j-publish
+            spdx:
+              name: docker-neo4j-publish
+              version: 3e584bcdacb6b8f64729dd4a4850f4b06a605238
+              packages:
+                - name: docker-neo4j-publish
+                  purl: pkg:github/neo4j/docker-neo4j-publish@3e584bcdacb6b8f64729dd4a4850f4b06a605238
+                  license: Apache-2.0
+            uid: 0
+            gid: 0
+      pipeline:
+        - name: install distribution and startup scripts
+          runs: |
+            set -eux -o pipefail
+
+            mkdir -p ${target.dir}/var/lib/neo4j
+            tar -xzf ${source.dir}/dozerdb-5.26.27.0-unix.tar.gz \
+              -C ${target.dir}/var/lib/neo4j \
+              --strip-components=1
+
+            cp -R \
+              ${source.dir}/docker-neo4j-publish/5.26.27/trixie/community/local-package \
+              ${target.dir}/startup
+            install -m 0644 ${source.dir}/neo4j-plugins.json \
+              ${target.dir}/startup/neo4j-plugins.json
+
+            # gosu is the hardened replacement for the upstream su-exec helper.
+            sed -i 's/su-exec/gosu/g' ${target.dir}/startup/docker-entrypoint.sh
+            mv ${target.dir}/startup/neo4j-admin-report.sh \
+              ${target.dir}/var/lib/neo4j/bin/neo4j-admin-report
+
+            sed -i 's/Package Type:.*/Package Type: docker trixie/' \
+              ${target.dir}/var/lib/neo4j/packaging_info
+            chmod 0755 ${target.dir}/startup/*.sh
+            chmod 0755 ${target.dir}/var/lib/neo4j/bin/*
+        - name: verify distribution
+          runs: |
+            set -eux -o pipefail
+
+            test -f ${target.dir}/var/lib/neo4j/lib/dozerdb-core-5.26.27-1.1.0.jar
+            test -f ${target.dir}/var/lib/neo4j/lib/dozerdb-browser-5.26.27.0.jar
+            test -d ${target.dir}/var/lib/neo4j/data
+            test -d ${target.dir}/var/lib/neo4j/logs
+            test -d ${target.dir}/var/lib/neo4j/plugins
+            test -d ${target.dir}/var/lib/neo4j/import
+
+            bash -n ${target.dir}/startup/docker-entrypoint.sh
+            jq -e '
+              has("apoc") and
+              has("apoc-extended") and
+              has("graph-data-science") and
+              has("open-gds") and
+              has("n10s") and
+              has("genai")
+            ' ${target.dir}/startup/neo4j-plugins.json
+
+            version_output="$(JAVA_HOME=/usr/lib/jvm/temurin-21 ${target.dir}/var/lib/neo4j/bin/neo4j version)"
+            echo "${version_output}"
+            echo "${version_output}" | grep -F '5.26.27'
+            java -version 2>&1 | grep -F '21.'
+      paths:
+        - type: file
+          path: ${source.dir}/neo4j-plugins.json
+          uid: 0
+          gid: 0
+          source: image/dozerdb/config/neo4j-plugins.json
+      outputs:
+        - source: ${target.dir}/var/lib/neo4j
+          target: /var/lib/neo4j
+          uid: 7474
+          gid: 7474
+          mode: "0744"
+        - source: ${target.dir}/startup
+          target: /startup
+          uid: 0
+          gid: 0
+        - source: ${target.dir}/startup/docker-entrypoint.sh
+          target: /usr/local/bin/docker-entrypoint.sh
+          uid: 0
+          gid: 0
+          mode: "0755"
+        - source: /opt/docker/sbom/dozerdb
+          target: /opt/docker/sbom/dozerdb
+          uid: 0
+          gid: 0
+  artifacts:
+    - name: ${GOSU_REFERENCE}
+      includes:
+        - opt/docker/sbom/gosu
+        - usr/local/sbin/gosu
+      uid: 0
+      gid: 0
+accounts:
+  run-as: neo4j
+  users:
+    - name: neo4j
+      uid: 7474
+      gid: 7474
+  groups:
+    - name: neo4j
+      gid: 7474
+      members:
+        - neo4j
+os-release:
+  name: Docker Hardened Images (Debian)
+  id: debian
+  version-id: "13"
+  version-codename: trixie
+  pretty-name: Docker Hardened Images/Debian GNU/Linux 13 (trixie)
+  home-url: https://docker.com/products/hardened-images/
+  bug-report-url: https://docker.com/support/
+environment:
+  JAVA_HOME: /usr/lib/jvm/temurin-21
+  LANG: C.UTF-8
+  NEO4J_EDITION: community
+  NEO4J_HOME: /var/lib/neo4j
+  PATH: /usr/local/sbin:/var/lib/neo4j/bin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+paths:
+  - type: symlink
+    path: /data
+    uid: 7474
+    gid: 7474
+    source: /var/lib/neo4j/data
+  - type: symlink
+    path: /logs
+    uid: 7474
+    gid: 7474
+    source: /var/lib/neo4j/logs
+annotations:
+  org.opencontainers.image.description: A minimal DozerDB image
+  org.opencontainers.image.licenses: GPL-3.0
+entrypoint:
+  - /usr/bin/tini
+  - -g
+  - --
+  - /startup/docker-entrypoint.sh
+cmd:
+  - neo4j
+ports:
+  - 7473/tcp
+  - 7474/tcp
+  - 7687/tcp

--- a/image/dozerdb/guides.md
+++ b/image/dozerdb/guides.md
@@ -1,0 +1,119 @@
+## How to use this image
+
+All examples use the public image. If you mirror the repository, replace `dhi.io/dozerdb:<tag>` with your mirrored image.
+Authenticate before pulling with `docker login dhi.io`.
+
+### Start DozerDB
+
+Replace `<tag>` and `<password>` with the image tag and a password of at least eight characters:
+
+```bash
+docker run -d --name dozerdb \
+  -e NEO4J_AUTH=neo4j/<password> \
+  -p 7473:7473 \
+  -p 7474:7474 \
+  -p 7687:7687 \
+  -v dozerdb-data:/data \
+  -v dozerdb-logs:/logs \
+  dhi.io/dozerdb:<tag>
+```
+
+Open `http://localhost:7474` for the browser UI or connect a Bolt client to `bolt://localhost:7687`.
+
+To disable authentication for local-only testing, set `NEO4J_AUTH=none`. Do not disable authentication on an exposed or
+production instance.
+
+### Configure DozerDB
+
+The image retains the Neo4j Docker environment-variable convention. Prefix a setting with `NEO4J_`, replace dots with
+single underscores, and replace literal underscores with double underscores. For example:
+
+```bash
+docker run --rm \
+  -e NEO4J_AUTH=none \
+  -e NEO4J_server_memory_heap_initial__size=512m \
+  -e NEO4J_server_memory_heap_max__size=512m \
+  -p 7474:7474 \
+  -p 7687:7687 \
+  dhi.io/dozerdb:<tag>
+```
+
+The entrypoint also supports readable mounts at `/conf`, `/ssl`, `/plugins`, `/import`, and `/licenses`. The runtime
+variant runs as UID/GID `7474:7474`; mounted writable directories must therefore be writable by UID 7474. `/data` and
+`/logs` are the persistent writable data paths.
+
+### Install registered Neo4j plugins
+
+The pinned DozerDB plugin registry supports `apoc`, `apoc-extended`, `graph-data-science` (mapped to open GDS), `open-gds`, `n10s`, and `genai`.
+Request plugins with a JSON array:
+
+```bash
+docker run --rm \
+  -e NEO4J_AUTH=none \
+  -e 'NEO4J_PLUGINS=["apoc"]' \
+  -p 7474:7474 \
+  -p 7687:7687 \
+  dhi.io/dozerdb:<tag>
+```
+
+Plugin downloads happen at container startup and require outbound HTTPS access. A mounted `/plugins` directory is
+optional; if supplied, ensure UID 7474 can write to it before starting the runtime image.
+
+### Use the development variant
+
+Tags ending in `-dev` run as root and include a shell, package manager, and common debugging tools. Use a dev variant for
+interactive diagnosis, not as the default production runtime:
+
+```bash
+docker run --rm -it --entrypoint bash dhi.io/dozerdb:<tag>-dev
+```
+
+## Non-hardened images vs Docker Hardened Images
+
+| Feature | `graphstack/dozerdb` | Docker Hardened DozerDB |
+| --- | --- | --- |
+| Base | General-purpose distribution | Minimal Debian 13 hardened base |
+| Runtime user | Starts as root and drops privileges | Starts directly as non-root UID 7474 |
+| Java | Upstream bundled/runtime Java | DHI Eclipse Temurin Java 21 runtime |
+| Package manager | Available in the standard image | Available only in `-dev` variants |
+| Entrypoint | Neo4j-compatible entrypoint | Same behavior, with `gosu` replacing `su-exec` |
+| Ports | 7473, 7474, and 7687 | 7473, 7474, and 7687 |
+| Persistent paths | `/data` and `/logs` | `/data` and `/logs` |
+
+## Migrate from `graphstack/dozerdb`
+
+1. Replace `graphstack/dozerdb:5.26.27` with `dhi.io/dozerdb:<tag>`.
+2. Keep the existing `NEO4J_*` configuration and port mappings.
+3. Ensure data, log, plugin, and import mounts are accessible to UID/GID `7474:7474`.
+4. Test authentication, plugin compatibility, and database upgrades against a copy of production data before switching.
+5. Use a `-dev` tag only when shell or package-manager access is required.
+
+This image consumes the checksum-pinned DozerDB 5.26.27.0 full distribution because no exact source tag maps to that
+release. See the catalog overview for the complete provenance boundary.
+
+## Troubleshooting
+
+### Permission errors
+
+The runtime image cannot change ownership of host paths because it starts as UID 7474. Pre-create bind-mounted
+directories with the correct ownership, or use named volumes. For a bind mount on Linux:
+
+```bash
+sudo install -d -o 7474 -g 7474 /srv/dozerdb/data /srv/dozerdb/logs
+```
+
+### Container exits during startup
+
+Inspect logs with `docker logs dozerdb`. Common causes are an invalid `NEO4J_AUTH` value, a password shorter than eight
+characters, a read-only mount, or a requested plugin that is unavailable for Neo4j 5.26.27.
+
+### Debugging the runtime image
+
+Use Docker Debug instead of adding tools to the production image:
+
+```bash
+docker debug dozerdb
+```
+
+Alternatively, reproduce the issue with the matching `-dev` tag. Do not use the dev variant as the long-running
+production image.

--- a/image/dozerdb/info.yaml
+++ b/image/dozerdb/info.yaml
@@ -1,0 +1,19 @@
+metadata:
+  display-name: DozerDB
+  short-description: DozerDB adds open source enterprise graph database features to Neo4j Community Edition.
+  featured: false
+  fips-compliant: false
+  fips-modules: []
+  stig-certified: false
+  home-url: https://dozerdb.org/
+  categories:
+    - databases-and-storage
+  alternatives:
+    - neo4j
+  included-tools:
+    - name: neo4j
+      description: Starts and manages the DozerDB-compatible Neo4j server process.
+    - name: neo4j-admin
+      description: Administers databases, backups, imports, configuration, and diagnostics.
+    - name: cypher-shell
+      description: Runs Cypher statements against DozerDB and Neo4j-compatible servers.

--- a/image/dozerdb/overview.md
+++ b/image/dozerdb/overview.md
@@ -1,0 +1,33 @@
+## About DozerDB
+
+DozerDB extends Neo4j Community Edition with open source graph database features through a bootstrapping plugin. This
+image packages DozerDB 5.26.27.0, which is based on Neo4j Community Edition 5.26.27 and runs on Java 21.
+
+For more information, visit https://dozerdb.org/ and the upstream organization at https://github.com/DozerDB.
+
+### Build provenance boundary
+
+DozerDB does not publish a source tag or commit that maps exactly to the 5.26.27.0 plugin and distribution. To avoid
+claiming source provenance that cannot be verified, this image uses the upstream full distribution at
+`https://dist.dozerdb.org/dozerdb-5.26.27.0-unix.tar.gz`, pinned to SHA-256
+`19888fc3f658fe69640ac3f90ad9c1177a50ae5f03fbf6c1835438ffe770264e`, as its reproducibility boundary.
+
+The Neo4j-compatible container entrypoint, utilities, and plugin registry come from the Neo4j 5.26.27 Docker publishing
+sources pinned at commit `3e584bcdacb6b8f64729dd4a4850f4b06a605238`. The entrypoint is changed only to use the pinned DHI `gosu` artifact in
+place of `su-exec`.
+
+## About Docker Hardened Images
+
+Docker Hardened Images are built to meet high security and compliance standards. They provide a trusted foundation for
+containerized workloads by incorporating security best practices from the start.
+
+### Why use Docker Hardened Images?
+
+These images include signed provenance and a complete Software Bill of Materials (SBOM) and VEX metadata. They are
+designed to secure your software supply chain while fitting into existing Docker workflows.
+
+## Trademarks
+
+This listing is prepared by Docker. All third-party product names, logos, and trademarks are the property of their
+respective owners and are used solely for identification. Docker claims no interest in those marks, and no affiliation,
+sponsorship, or endorsement is implied.


### PR DESCRIPTION
## Description

Adds Debian 13 Docker Hardened Image definitions for DozerDB 5.26.27.0, based on Neo4j Community Edition 5.26.27.

## Type of Change

- [x] New image
- [ ] New Helm chart
- [ ] New package
- [ ] Documentation improvement or correction
- [ ] Example configuration or use case
- [ ] Community tooling or script
- [ ] Website or catalog enhancement
- [ ] Bug fix
- [ ] Other (please describe):

## Related Issues

Fixes #495

## Changes Made

- Add Debian 13 runtime and development variants for `dozerdb` with Java 21 and Neo4j-compatible startup behavior.
- Consume the upstream 5.26.27.0 distribution at a pinned SHA-256 and pin Neo4j's 5.26.27 container startup scripts by commit.
- Preserve DozerDB's official open-GDS plugin registry, use the DHI `gosu` artifact, and run the production image as UID/GID 7474.
- Add catalog metadata, operational/migration guides, and explicit documentation of the upstream source-provenance boundary.

## Testing

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

Local validation performed:
- Parsed all new YAML with `yq`.
- Validated both build specs with `check-jsonschema==0.35.0` against `.spec.json`.
- Validated `info.yaml` against `.info.spec.json` and plugin JSON with `jq`.
- Verified the DozerDB distribution SHA-256, pinned startup commit/path, and semantic equality of the plugin registry with the official `graphstack/dozerdb:5.26.27` OCI image.
- Attempted full DHI `docker buildx build`; local Docker Desktop and both builders returned `EOF`, including after a bounded restart, so full image builds could not complete in this environment.

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] My changes follow the repository's style and conventions
- [x] I have updated documentation as needed
- [x] My commit messages are clear and descriptive

---

> **By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
