### PR TITLE
Fix CDI importer image: add missing binary

### DIFF
--- a/image/cdi-importer/debian-13/1.yaml
+++ b/image/cdi-importer/debian-13/1.yaml
@@ -38,6 +38,7 @@ contents:
     - nbdkit
     - qemu-utils
     - tzdata
+    - util-linux
   builds:
     - name: cdi-importer
       work-dir: /go/src/kubevirt.io/containerized-data-importer


### PR DESCRIPTION
## Description

Fixes the CDI importer image.

CDI importer pods run `/usr/sbin/blockdev` when importing to a block volume (see https://github.com/kubevirt/containerized-data-importer/blob/v1.66.0/pkg/importer/file.go#L20).

The DHI cdi-importer runtime image does not contain that binary, causing imports to fail with: `fork/exec
/usr/sbin/blockdev: no such file or directory`.

## Type of Change

- [ ] New image
- [ ] New Helm chart
- [ ] New package
- [ ] Documentation improvement or correction
- [ ] Example configuration or use case
- [ ] Community tooling or script
- [ ] Website or catalog enhancement
- [x] Bug fix
- [ ] Other (please describe):

## Changes Made

- Add the `util-linux` package to the image

## Testing

After rebuilding the image, the binary is now present:

```
docker run --rm \
    --entrypoint /usr/sbin/blockdev \
    cdi-importer:blockdev-test \
    --version

blockdev from util-linux 2.41
```

I also tested the image in my own workflow where I use CDI, and it imported correctly.

- [x] I have tested these changes locally
- [x] All existing tests pass
- [ ] I have added new tests (if applicable)

## Screenshots (if applicable)

N/A

## Checklist

- [x] My changes follow the repository's style and conventions
- [x] I have updated documentation as needed
- [x] My commit messages are clear and descriptive

---

> **By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
