### PR TITLE
feat: add FreeRADIUS image

### DIFF
--- a/image/freeradius/alpine-3.23/3.yaml
+++ b/image/freeradius/alpine-3.23/3.yaml
@@ -1,0 +1,112 @@
+# syntax=dhi.io/build:2-alpine3.23
+
+name: FreeRADIUS 3.0.x
+image: dhi.io/freeradius
+variant: runtime
+tags:
+  - 3-alpine3.23
+  - 3.0-alpine3.23
+  - 3.0.27-alpine3.23
+platforms:
+  - linux/amd64
+  - linux/arm64
+vars:
+  SEMVER_MAJOR_MINOR_VERSION: "3.0"
+  SEMVER_MAJOR_VERSION: "3"
+  SEMVER_VERSION: 3.0.27
+  VERSION: 3.0.27-r2
+contents:
+  repositories:
+    - https://dhi.io/apk/alpine/v3.23/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.23/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.23/community
+  keyring:
+    - https://dhi.io/keyring/dhi-apk@docker-0F81AD7700D99184.rsa.pub
+  packages:
+    - alpine-baselayout-data
+    - freeradius=3.0.27-r2
+    - tzdata
+  builds:
+    - name: freeradius
+      contents:
+        packages:
+          - alpine-baselayout-data
+          - busybox
+          - freeradius=3.0.27-r2
+      pipeline:
+        - name: configure and validate
+          runs: |
+            set -eux -o pipefail
+
+            setup-freeradius enable-default-mods
+
+            # The image starts unprivileged, so radiusd must not attempt to
+            # change users or groups after startup.
+            sed -i \
+              -e 's/^[[:space:]]*user = radius/# user = radius/' \
+              -e 's/^[[:space:]]*group = radius/# group = radius/' \
+              /etc/raddb/radiusd.conf
+
+            test -L /etc/raddb/mods-enabled/files
+            ! grep -Eq '^[[:space:]]*(user|group)[[:space:]]*=' /etc/raddb/radiusd.conf
+            radiusd -XC
+
+            chgrp -R 65532 /etc/raddb
+            chmod -R g+rX /etc/raddb
+      outputs:
+        - source: /
+          target: /
+          uid: 0
+          gid: 0
+          diff: true
+accounts:
+  run-as: nonroot
+  users:
+    - name: nonroot
+      uid: 65532
+      gid: 65532
+  groups:
+    - name: nonroot
+      gid: 65532
+      members:
+        - nonroot
+os-release:
+  name: Docker Hardened Images (Alpine)
+  id: alpine
+  version-id: "3.23"
+  pretty-name: Docker Hardened Images/Alpine Linux v3.23
+  home-url: https://docker.com/products/hardened-images/
+  bug-report-url: https://docker.com/support/
+environment:
+  FREERADIUS_VERSION: 3.0.27
+paths:
+  - type: directory
+    path: /run/radiusd
+    uid: 65532
+    gid: 65532
+    mode: "0755"
+  - type: directory
+    path: /var/cache/radiusd
+    uid: 65532
+    gid: 65532
+    mode: "0750"
+  - type: directory
+    path: /var/lib/radiusd
+    uid: 65532
+    gid: 65532
+    mode: "0750"
+  - type: directory
+    path: /var/log/radius
+    uid: 65532
+    gid: 65532
+    mode: "0750"
+annotations:
+  org.opencontainers.image.description: A minimal FreeRADIUS image
+  org.opencontainers.image.licenses: GPL-2.0-or-later
+entrypoint:
+  - radiusd
+cmd:
+  - -f
+ports:
+  - 1812/udp
+  - 1813/udp

--- a/image/freeradius/alpine-3.24/3.yaml
+++ b/image/freeradius/alpine-3.24/3.yaml
@@ -1,0 +1,115 @@
+# syntax=dhi.io/build:2-alpine3.23
+
+name: FreeRADIUS 3.0.x
+image: dhi.io/freeradius
+variant: runtime
+tags:
+  - 3-alpine
+  - 3.0-alpine
+  - 3-alpine3.24
+  - 3.0.27-alpine
+  - 3.0-alpine3.24
+  - 3.0.27-alpine3.24
+platforms:
+  - linux/amd64
+  - linux/arm64
+vars:
+  SEMVER_MAJOR_MINOR_VERSION: "3.0"
+  SEMVER_MAJOR_VERSION: "3"
+  SEMVER_VERSION: 3.0.27
+  VERSION: 3.0.27-r3
+contents:
+  repositories:
+    - https://dhi.io/apk/alpine/v3.24/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.24/main
+    - https://dl-cdn.alpinelinux.org/alpine/v3.24/community
+  keyring:
+    - https://dhi.io/keyring/dhi-apk@docker-0F81AD7700D99184.rsa.pub
+  packages:
+    - alpine-baselayout-data
+    - freeradius=3.0.27-r3
+    - tzdata
+  builds:
+    - name: freeradius
+      contents:
+        packages:
+          - alpine-baselayout-data
+          - busybox
+          - freeradius=3.0.27-r3
+      pipeline:
+        - name: configure and validate
+          runs: |
+            set -eux -o pipefail
+
+            setup-freeradius enable-default-mods
+
+            # The image starts unprivileged, so radiusd must not attempt to
+            # change users or groups after startup.
+            sed -i \
+              -e 's/^[[:space:]]*user = radius/# user = radius/' \
+              -e 's/^[[:space:]]*group = radius/# group = radius/' \
+              /etc/raddb/radiusd.conf
+
+            test -L /etc/raddb/mods-enabled/files
+            ! grep -Eq '^[[:space:]]*(user|group)[[:space:]]*=' /etc/raddb/radiusd.conf
+            radiusd -XC
+
+            chgrp -R 65532 /etc/raddb
+            chmod -R g+rX /etc/raddb
+      outputs:
+        - source: /
+          target: /
+          uid: 0
+          gid: 0
+          diff: true
+accounts:
+  run-as: nonroot
+  users:
+    - name: nonroot
+      uid: 65532
+      gid: 65532
+  groups:
+    - name: nonroot
+      gid: 65532
+      members:
+        - nonroot
+os-release:
+  name: Docker Hardened Images (Alpine)
+  id: alpine
+  version-id: "3.24"
+  pretty-name: Docker Hardened Images/Alpine Linux v3.24
+  home-url: https://docker.com/products/hardened-images/
+  bug-report-url: https://docker.com/support/
+environment:
+  FREERADIUS_VERSION: 3.0.27
+paths:
+  - type: directory
+    path: /run/radiusd
+    uid: 65532
+    gid: 65532
+    mode: "0755"
+  - type: directory
+    path: /var/cache/radiusd
+    uid: 65532
+    gid: 65532
+    mode: "0750"
+  - type: directory
+    path: /var/lib/radiusd
+    uid: 65532
+    gid: 65532
+    mode: "0750"
+  - type: directory
+    path: /var/log/radius
+    uid: 65532
+    gid: 65532
+    mode: "0750"
+annotations:
+  org.opencontainers.image.description: A minimal FreeRADIUS image
+  org.opencontainers.image.licenses: GPL-2.0-or-later
+entrypoint:
+  - radiusd
+cmd:
+  - -f
+ports:
+  - 1812/udp
+  - 1813/udp

--- a/image/freeradius/debian-13/3.yaml
+++ b/image/freeradius/debian-13/3.yaml
@@ -1,0 +1,179 @@
+# syntax=dhi.io/build:2-debian13
+
+name: FreeRADIUS 3.2.x
+image: dhi.io/freeradius
+variant: runtime
+tags:
+  - "3"
+  - "3.2"
+  - 3.2.7
+  - 3-debian
+  - 3-debian13
+  - 3.2-debian
+  - 3.2-debian13
+  - 3.2.7-debian
+  - 3.2.7-debian13
+platforms:
+  - linux/amd64
+  - linux/arm64
+vars:
+  SEMVER_MAJOR_MINOR_VERSION: "3.2"
+  SEMVER_MAJOR_VERSION: "3"
+  SEMVER_VERSION: 3.2.7
+  VERSION: 3.2.7+dfsg-1+deb13u2
+contents:
+  repositories:
+    - deb http://deb.debian.org/debian trixie main
+    - deb [signed-by=/usr/share/keyrings/dhi-deb-main.gpg] http://dhi.io/deb/debian/main trixie main
+  keyring:
+    - https://ftp-master.debian.org/keys/archive-key-13.asc
+    - https://dhi.io/keyring/dhi-deb-gpg.D46852F6925E9F71.key
+  packages:
+    - base-files
+    - ca-certificates-bundle
+    - freeradius-common=3.2.7+dfsg-1+deb13u2
+    - freeradius-config=3.2.7+dfsg-1+deb13u2
+    - freeradius=3.2.7+dfsg-1+deb13u2
+    - libcap2
+    - libcrypt1
+    - libct4
+    - libfreeradius3=3.2.7+dfsg-1+deb13u2
+    - libgdbm6t64
+    - libjson-c5
+    - libpam0g
+    - libpcap0.8t64
+    - libperl5.40
+    - libreadline8t64
+    - libsqlite3-0
+    - libssl3t64
+    - libsystemd0
+    - libtalloc2
+    - libwbclient0
+    - perl
+    - tzdata
+  builds:
+    - name: freeradius
+      contents:
+        packages:
+          - base-files
+          - ca-certificates-bundle
+          - coreutils
+          - dash
+          - freeradius-common=3.2.7+dfsg-1+deb13u2
+          - freeradius-config=3.2.7+dfsg-1+deb13u2
+          - freeradius=3.2.7+dfsg-1+deb13u2
+          - grep
+          - libcap2
+          - libcrypt1
+          - libct4
+          - libfreeradius3=3.2.7+dfsg-1+deb13u2
+          - libgdbm6t64
+          - libjson-c5
+          - libpam0g
+          - libpcap0.8t64
+          - libperl5.40
+          - libreadline8t64
+          - libsqlite3-0
+          - libssl3t64
+          - libsystemd0
+          - libtalloc2
+          - libwbclient0
+          - make
+          - openssl
+          - perl
+          - sed
+      pipeline:
+        - name: configure and validate
+          runs: |
+            set -eux -o pipefail
+
+            config=/etc/freeradius/3.0/radiusd.conf
+
+            for site in default inner-tunnel; do
+              ln -s "../sites-available/$site" "/etc/freeradius/3.0/sites-enabled/$site"
+            done
+            for module in always attr_filter chap detail detail.log \
+              digest dynamic_clients eap echo exec expiration expr files \
+              linelog logintime mschap ntlm_auth pap passwd preprocess \
+              radutmp realm replicate soh sradutmp unix unpack utf8; do
+              ln -s "../mods-available/$module" "/etc/freeradius/3.0/mods-enabled/$module"
+            done
+
+            eap=/etc/freeradius/3.0/mods-available/eap
+            sed -i \
+              -e 's|/etc/ssl/private/ssl-cert-snakeoil.key|${certdir}/server.key|' \
+              -e 's|/etc/ssl/certs/ssl-cert-snakeoil.pem|${certdir}/server.pem|' \
+              "$eap"
+            make -C /etc/freeradius/3.0/certs
+
+            # The image starts unprivileged, so FreeRADIUS must not attempt to
+            # change users or groups after startup.
+            sed -i \
+              -e 's/^[[:space:]]*user = freerad/# user = freerad/' \
+              -e 's/^[[:space:]]*group = freerad/# group = freerad/' \
+              "$config"
+
+            test -L /etc/freeradius/3.0/mods-enabled/files
+            ! grep -Eq '^[[:space:]]*(user|group)[[:space:]]*=' "$config"
+            freeradius -XC
+
+            chgrp -R 65532 /etc/freeradius
+            chmod -R g+rX /etc/freeradius
+      outputs:
+        - source: /
+          target: /
+          uid: 0
+          gid: 0
+          diff: true
+accounts:
+  run-as: freerad
+  users:
+    - name: freerad
+      uid: 65532
+      gid: 65532
+  groups:
+    - name: freerad
+      gid: 65532
+      members:
+        - freerad
+os-release:
+  name: Docker Hardened Images (Debian)
+  id: debian
+  version-id: "13"
+  version-codename: trixie
+  pretty-name: Docker Hardened Images/Debian GNU/Linux 13 (trixie)
+  home-url: https://docker.com/products/hardened-images/
+  bug-report-url: https://docker.com/support/
+environment:
+  FREERADIUS_VERSION: 3.2.7
+paths:
+  - type: directory
+    path: /run/freeradius
+    uid: 65532
+    gid: 65532
+    mode: "0755"
+  - type: directory
+    path: /var/cache/freeradius
+    uid: 65532
+    gid: 65532
+    mode: "0750"
+  - type: directory
+    path: /var/lib/freeradius
+    uid: 65532
+    gid: 65532
+    mode: "0750"
+  - type: directory
+    path: /var/log/freeradius
+    uid: 65532
+    gid: 65532
+    mode: "0750"
+annotations:
+  org.opencontainers.image.description: A minimal FreeRADIUS image
+  org.opencontainers.image.licenses: GPL-2.0-or-later
+entrypoint:
+  - freeradius
+cmd:
+  - -f
+ports:
+  - 1812/udp
+  - 1813/udp

--- a/image/freeradius/info.yaml
+++ b/image/freeradius/info.yaml
@@ -1,0 +1,15 @@
+metadata:
+  display-name: FreeRADIUS
+  short-description: FreeRADIUS is a high-performance, configurable multi-protocol policy server for centralized network authentication and authorization.
+  featured: false
+  fips-compliant: false
+  fips-modules: []
+  stig-certified: false
+  home-url: https://www.freeradius.org/
+  categories:
+    - networking
+    - security
+  alternatives: []
+  included-tools:
+    - name: radiusd
+      description: The FreeRADIUS authentication, authorization, and accounting server


### PR DESCRIPTION
## Description

Add proposed Docker Hardened Images for FreeRADIUS on Alpine 3.23, Alpine 3.24, and Debian 13. The Alpine variants use the catalog-maintained FreeRADIUS 3.0.27 packages; the Debian variant uses Debian trixie's FreeRADIUS 3.2.7 packages alongside the DHI Debian base. All variants run as UID/GID 65532, validate their default configuration during the build, and expose the standard RADIUS authentication and accounting UDP ports.

## Type of Change

- [x] New image
- [ ] New Helm chart
- [ ] New package
- [ ] Documentation improvement or correction
- [ ] Example configuration or use case
- [ ] Community tooling or script
- [ ] Website or catalog enhancement
- [ ] Bug fix
- [ ] Other (please describe):

## Related Issues

Closes #536

## Changes Made

- Add FreeRADIUS 3.0.27 runtime definitions for Alpine 3.23 and Alpine 3.24
- Add a FreeRADIUS 3.2.7 runtime definition for Debian 13, including the explicit external package dependency closure
- Reproduce Debian's packaged default site/module setup and generate self-contained EAP development certificates
- Run FreeRADIUS as the non-root UID/GID 65532 with writable runtime, cache, state, and log paths
- Validate the packaged configuration during each build
- Add catalog metadata and expose `1812/udp` and `1813/udp`

## Testing

- [x] I have tested these changes locally
- [ ] All existing tests pass
- [x] I have added new tests (if applicable)

Validation performed:

- Strict YAML parsing with duplicate-key detection, no trailing whitespace, and clean `git diff --check`
- All three runtime definitions pass `.spec.json`; metadata passes `.info.spec.json` with `check-jsonschema` 0.34.0
- Aikido SAST and secrets scan of all four first-party files: zero issues
- DHI frontend builds pass on `linux/arm64` for Alpine 3.23, Alpine 3.24, and Debian 13; each reports `Configuration appears to be OK`
- Final Alpine 3.24 image passes `radiusd -XC` and remains running as UID 65532
- Final Debian 13 image passes `freeradius -XC`; metadata is `User=65532`, `Entrypoint=["freeradius"]`, `Cmd=["-f"]`, and the live server remains running as UID 65532

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] My changes follow the repository's style and conventions
- [x] I have updated documentation as needed
- [x] My commit messages are clear and descriptive

---

> **By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
