### PR TITLE
python: drop -dev packages from debian-13 runtime images

### DIFF
--- a/image/python/debian-13/3.10.yaml
+++ b/image/python/debian-13/3.10.yaml
@@ -34,18 +34,14 @@ contents:
     - ca-certificates
     - libbz2-1.0
     - libc6
-    - libc6-dev
     - libcrypt1
     - libdb5.3t64
-    - libexpat1-dev
     - libffi8
     - libgcc-s1
     - libgdbm-compat4t64
     - liblzma5
     - libncursesw6
     - libpython-3.10
-    - libpython-3.10-dev
-    - libpython-3.10-dev=3.10.21-1
     - libpython-3.10-minimal
     - libpython-3.10-minimal=3.10.21-1
     - libpython-3.10-stdlib
@@ -61,8 +57,6 @@ contents:
     - ncurses-bin
     - netbase
     - python-3.10
-    - python-3.10-dev
-    - python-3.10-dev=3.10.21-1
     - python-3.10-minimal
     - python-3.10-minimal=3.10.21-1
     - python-3.10=3.10.21-1
@@ -80,7 +74,6 @@ contents:
     - python3-wheel=0.48.0-0
     - tzdata
     - zlib1g
-    - zlib1g-dev
 accounts:
   run-as: nonroot
   users:

--- a/image/python/debian-13/3.11.yaml
+++ b/image/python/debian-13/3.11.yaml
@@ -34,18 +34,14 @@ contents:
     - ca-certificates
     - libbz2-1.0
     - libc6
-    - libc6-dev
     - libcrypt1
     - libdb5.3t64
-    - libexpat1-dev
     - libffi8
     - libgcc-s1
     - libgdbm-compat4t64
     - liblzma5
     - libncursesw6
     - libpython-3.11
-    - libpython-3.11-dev
-    - libpython-3.11-dev=3.11.16-1
     - libpython-3.11-minimal
     - libpython-3.11-minimal=3.11.16-1
     - libpython-3.11-stdlib
@@ -61,8 +57,6 @@ contents:
     - ncurses-bin
     - netbase
     - python-3.11
-    - python-3.11-dev
-    - python-3.11-dev=3.11.16-1
     - python-3.11-minimal
     - python-3.11-minimal=3.11.16-1
     - python-3.11=3.11.16-1
@@ -80,7 +74,6 @@ contents:
     - python3-wheel=0.48.0-0
     - tzdata
     - zlib1g
-    - zlib1g-dev
 accounts:
   run-as: nonroot
   users:

--- a/image/python/debian-13/3.12.yaml
+++ b/image/python/debian-13/3.12.yaml
@@ -34,18 +34,14 @@ contents:
     - ca-certificates
     - libbz2-1.0
     - libc6
-    - libc6-dev
     - libcrypt1
     - libdb5.3t64
-    - libexpat1-dev
     - libffi8
     - libgcc-s1
     - libgdbm-compat4t64
     - liblzma5
     - libncursesw6
     - libpython-3.12
-    - libpython-3.12-dev
-    - libpython-3.12-dev=3.12.14-1
     - libpython-3.12-minimal
     - libpython-3.12-minimal=3.12.14-1
     - libpython-3.12-stdlib
@@ -61,8 +57,6 @@ contents:
     - ncurses-bin
     - netbase
     - python-3.12
-    - python-3.12-dev
-    - python-3.12-dev=3.12.14-1
     - python-3.12-minimal
     - python-3.12-minimal=3.12.14-1
     - python-3.12=3.12.14-1
@@ -80,7 +74,6 @@ contents:
     - python3-wheel=0.48.0-0
     - tzdata
     - zlib1g
-    - zlib1g-dev
 accounts:
   run-as: nonroot
   users:

--- a/image/python/debian-13/3.13.yaml
+++ b/image/python/debian-13/3.13.yaml
@@ -34,18 +34,14 @@ contents:
     - ca-certificates
     - libbz2-1.0
     - libc6
-    - libc6-dev
     - libcrypt1
     - libdb5.3t64
-    - libexpat1-dev
     - libffi8
     - libgcc-s1
     - libgdbm-compat4t64
     - liblzma5
     - libncursesw6
     - libpython-3.13
-    - libpython-3.13-dev
-    - libpython-3.13-dev=3.13.15-1
     - libpython-3.13-minimal
     - libpython-3.13-minimal=3.13.15-1
     - libpython-3.13-stdlib
@@ -61,8 +57,6 @@ contents:
     - ncurses-bin
     - netbase
     - python-3.13
-    - python-3.13-dev
-    - python-3.13-dev=3.13.15-1
     - python-3.13-minimal
     - python-3.13-minimal=3.13.15-1
     - python-3.13=3.13.15-1
@@ -80,7 +74,6 @@ contents:
     - python3-wheel=0.48.0-0
     - tzdata
     - zlib1g
-    - zlib1g-dev
 accounts:
   run-as: nonroot
   users:

--- a/image/python/debian-13/3.14.yaml
+++ b/image/python/debian-13/3.14.yaml
@@ -37,18 +37,14 @@ contents:
     - ca-certificates
     - libbz2-1.0
     - libc6
-    - libc6-dev
     - libcrypt1
     - libdb5.3t64
-    - libexpat1-dev
     - libffi8
     - libgcc-s1
     - libgdbm-compat4t64
     - liblzma5
     - libncursesw6
     - libpython-3.14
-    - libpython-3.14-dev
-    - libpython-3.14-dev=3.14.7-1
     - libpython-3.14-minimal
     - libpython-3.14-minimal=3.14.7-1
     - libpython-3.14-stdlib
@@ -64,8 +60,6 @@ contents:
     - ncurses-bin
     - netbase
     - python-3.14
-    - python-3.14-dev
-    - python-3.14-dev=3.14.7-1
     - python-3.14-minimal
     - python-3.14-minimal=3.14.7-1
     - python-3.14=3.14.7-1
@@ -83,7 +77,6 @@ contents:
     - python3-wheel=0.48.0-0
     - tzdata
     - zlib1g
-    - zlib1g-dev
 accounts:
   run-as: nonroot
   users:


### PR DESCRIPTION
## Description

The `python/debian-13` runtime definitions declare five `-dev` packages. This removes them, so the
runtime image stops shipping compiler headers. The `-dev` variants keep them.

`libc6-dev` also pulls in `libc-dev-bin`, `libcrypt-dev`, `linux-libc-dev` and `rpcsvc-proto`, so
nine packages leave the image.

`image/python/debian-12/3.13.yaml` is already like this: same `variant: runtime`, no `-dev`
packages. `image/php/debian-13/8.2-fpm.yaml` shows where build packages belong, under
`builds[].contents.packages`. The node, golang, ruby and nginx debian-13 runtimes also declare none.

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #549

## Changes Made

- Removed `libc6-dev`, `libexpat1-dev`, `libpython-<v>-dev`, `python-<v>-dev` and `zlib1g-dev` from
  `contents.packages` in `image/python/debian-13/{3.10,3.11,3.12,3.13,3.14}.yaml`.
- Left `*-dev.yaml`, `*-sfw-dev.yaml` and `*-sfw-ent-dev.yaml` alone.

## Testing

- [x] I have tested these changes locally

I resolved the package set the edited definition produces, then filtered a scan of
`dhi.io/python:3.13@sha256:d022670f9ec8831951a87a88d4438ec4e96219f70b5aae05ce24ccf565d9bda7`
(linux/amd64, Trivy 0.70.0, 2026-08-26) down to that set:

| | findings | Critical | High |
| --- | --- | --- | --- |
| as shipped | 595 | 1 | 58 |
| with this change | 36 | 0 | 6 |

The Critical that goes away is CVE-2026-43185 in `linux-libc-dev`, which Debian does not fix.

Removing these packages costs nothing at run time. They own link-time files only: the unversioned
`.so` symlinks, the C headers and `/usr/bin/python3-config`. The loader uses
`libpython3.13.so.1.0`, `libc.so.6`, `libz.so.1` and `libexpat.so.1`, owned by packages that stay.
Building C extensions inside the runtime image stops working, which is what the `-dev` variant is
for.

## Checklist

- [x] My changes follow the repository's style and conventions
- [ ] I have updated documentation as needed
- [x] My commit messages are clear and descriptive
