### PR TITLE
Add GitLab hardened Helm chart

### DIFF
--- a/chart/gitlab/config/NOTES.txt
+++ b/chart/gitlab/config/NOTES.txt
@@ -1,0 +1,23 @@
+===============================================================================
+ 🐳  {{ .Chart.Name | upper }} — A Docker Hardened Helm Chart
+===============================================================================
+
+This restricted GitLab chart uses digest-pinned Docker Hardened Images.
+It does not install PostgreSQL, Redis, Gitaly, object storage, ingress, TLS
+management, or automatic secret generation. Configure those prerequisites
+before installation; the placeholder *.example.invalid endpoints fail closed.
+
+Release:      {{ .Release.Name }}
+Namespace:    {{ .Release.Namespace }}
+Chart:        {{ .Chart.Name }} {{ .Chart.Version }}
+App version:  {{ .Chart.AppVersion }}
+
+Verify the release:
+  helm status {{ .Release.Name }} -n {{ .Release.Namespace }}
+  kubectl get pods -n {{ .Release.Namespace }}
+
+Run the upstream login test after all workloads become ready:
+  helm test {{ .Release.Name }} -n {{ .Release.Namespace }}
+
+See the chart guide for the required external services, secrets, and values.
+===============================================================================

--- a/chart/gitlab/config/files/dhi-gitlab-cng/LICENSE
+++ b/chart/gitlab/config/files/dhi-gitlab-cng/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/chart/gitlab/config/files/dhi-gitlab-cng/README.md
+++ b/chart/gitlab/config/files/dhi-gitlab-cng/README.md
@@ -1,0 +1,15 @@
+# GitLab CNG helper scripts
+
+These files are copied from `gitlab-org/build/CNG` tag `v19.1.6` to match the
+GitLab 19.1 application used by chart 10.1.6:
+
+https://gitlab.com/gitlab-org/build/CNG/-/tree/v19.1.6/gitlab-rails/scripts
+
+They are distributed under the included MIT license. Two path-only adaptations
+allow the scripts to run from the chart-mounted `/opt/gitlab/cng-scripts`
+directory without replacing scripts already supplied by Docker Hardened Images:
+
+- `wait-for-deps` invokes `/opt/gitlab/cng-scripts/rails-dependencies`.
+- `db-migrate` invokes `/opt/gitlab/cng-scripts/custom-instance-setup`.
+
+All other helper source is unchanged from CNG v19.1.6.

--- a/chart/gitlab/config/files/dhi-gitlab-cng/custom-instance-setup
+++ b/chart/gitlab/config/files/dhi-gitlab-cng/custom-instance-setup
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Workaround for disabling the authorized_keys write to the database.
+# A proper fix is being tracked in: https://gitlab.com/gitlab-org/gitlab-ee/issues/4156
+puts 'Disabling authorized keys write in the database.'
+setting = ::ApplicationSetting.current_without_cache || ::ApplicationSetting.create_from_defaults
+setting.update_attribute(:authorized_keys_enabled, false)
+
+puts 'Enabling incremental logging of CI jobs.'
+setting.update_attribute(:ci_job_live_trace_enabled, true)
+
+puts 'Registering OAuth applications.'
+secrets_dir = ENV['OAUTH_SECRET_DIR'] || '/etc/gitlab/oauth-secrets'
+Dir.glob("#{secrets_dir}/*").each do |app_path|
+  app = File.basename(app_path).titleize
+  puts "Registering #{app} as an OAuth application."
+  begin
+    uid = File.read(File.join(app_path, 'appid')).strip
+    secret = File.read(File.join(app_path, 'appsecret')).strip
+    redirecturi = File.read(File.join(app_path, 'redirecturi')).strip
+
+    oauth_app = Authn::OauthApplication.where({ redirect_uri: redirecturi, name: app }).by_uid_and_secret(uid, secret)
+    if oauth_app
+      oauth_app.update_column(:organization_id, Organizations::Organization::DEFAULT_ORGANIZATION_ID) if oauth_app.organization_id.nil?
+    else
+      Authn::OauthApplication.where({ redirect_uri: redirecturi, name: app, uid: uid, secret: secret, organization_id: Organizations::Organization::DEFAULT_ORGANIZATION_ID }).create!
+    end
+    puts "Successfully registered #{app}."
+  rescue Errno::ENOENT
+    puts "Necessary secrets not found. Skipping registration of #{app}"
+    next
+  rescue ActiveRecord::ActiveRecordError, RuntimeError
+    puts "Failed to register #{app}."
+    next
+  end
+end

--- a/chart/gitlab/config/files/dhi-gitlab-cng/db-migrate
+++ b/chart/gitlab/config/files/dhi-gitlab-cng/db-migrate
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+ROOT_PASSWORD_FILE="${ROOT_PASSWORD_FILE:-/srv/gitlab/config/initial_root_password}"
+
+if [ -f "${ROOT_PASSWORD_FILE}" ]; then
+  export GITLAB_ROOT_PASSWORD=$(cat "${ROOT_PASSWORD_FILE}")
+fi
+
+SHARED_RUNNERS_REGISTRATION_TOKEN_FILE="${SHARED_RUNNERS_REGISTRATION_TOKEN_FILE:-/srv/gitlab/config/gitlab_shared_runners_registration_token}"
+
+if [ -f "${SHARED_RUNNERS_REGISTRATION_TOKEN_FILE}" ] && [ -r "${SHARED_RUNNERS_REGISTRATION_TOKEN_FILE}" ]; then
+  export GITLAB_SHARED_RUNNERS_REGISTRATION_TOKEN=$(cat "${SHARED_RUNNERS_REGISTRATION_TOKEN_FILE}")
+fi
+
+echo "Checking database migrations are up-to-date"
+
+# Seed or migrate the database via gitlab:db:configure
+echo "Performing migrations (this will initialized if needed)"
+cd /srv/gitlab
+/srv/gitlab/bin/rake gitlab:db:configure
+
+echo "Performing custom instance setup"
+/srv/gitlab/bin/rails runner -e production /opt/gitlab/cng-scripts/custom-instance-setup

--- a/chart/gitlab/config/files/dhi-gitlab-cng/lib/bypass_schema_version_check.rb
+++ b/chart/gitlab/config/files/dhi-gitlab-cng/lib/bypass_schema_version_check.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Checks
+  module BypassSchemaVersionCheck
+    BYPASS_SCHEMA_VERSION_KEY = 'BYPASS_SCHEMA_VERSION'
+    BYPASS_CLICKHOUSE_SCHEMA_VERSION_KEY = 'BYPASS_CLICKHOUSE_SCHEMA_VERSION'
+
+    def bypass_schema_version_check
+      downcase_value = ENV[BYPASS_SCHEMA_VERSION_KEY].to_s.downcase
+
+      return false if downcase_value.empty?
+
+      downcase_value != 'false' && downcase_value != '0'
+    end
+
+    def bypass_clickhouse_schema_version_check
+      downcase_value = ENV[BYPASS_CLICKHOUSE_SCHEMA_VERSION_KEY].to_s.downcase
+
+      # We bypass the ClickHouse schema version check by default until the next required stop along the upgrade path.
+      return true if downcase_value.empty?
+
+      downcase_value != 'false' && downcase_value != '0'
+    end
+  end
+end

--- a/chart/gitlab/config/files/dhi-gitlab-cng/lib/checks/clickhouse.rb
+++ b/chart/gitlab/config/files/dhi-gitlab-cng/lib/checks/clickhouse.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+require 'yaml'
+require 'net/http'
+require 'click_house/client'
+
+module Checks
+  # Perform checks of ClickHouse dependency.
+  # Usage: `Checks::ClickHouse.run`
+  module ClickHouse
+    SCHEMA_MIGRATIONS_TABLE = 'schema_migrations'
+
+    def self.run
+      unless raw_config_file_exists?
+        log 'INFO: ClickHouse is not configured. Skipping migration checks.'
+        return true
+      end
+
+      if skip_checks?
+        log 'WARN: ClickHouse migration check explicitly skipped. This is NOT recommended for production environments.'
+        return true
+      end
+
+      # ClickHouse databases map an identifier to a configuration.
+      # This can be run only once, so we should not run this within check_all_databases
+      configure_databases
+
+      counter = 1
+      passed = false
+      until (counter == wait_for_timeout) || passed
+        passed = check_all_databases
+        sleep sleep_duration unless passed
+        counter += 1
+      end
+      passed
+    end
+
+    # Explicitly check if checks should be skipped by user configuration:
+    # When running tests or other non-production environments, setting the environment variable
+    # `SKIP_CLICKHOUSE_SCHEMA_VERSION_CHECK=YesReally` will bypass the schema version check.
+    # See: https://gitlab.com/gitlab-com/gl-infra/delivery/-/issues/21637
+    def self.skip_checks?
+      (ENV['SKIP_CLICKHOUSE_SCHEMA_VERSION_CHECK'] || '') == 'YesReally'
+    end
+
+    def self.wait_for_timeout
+      ENV['WAIT_FOR_TIMEOUT'].to_i
+    end
+
+    def self.sleep_duration
+      ENV['SLEEP_DURATION'].to_i
+    end
+
+    def self.config_directory
+      ENV['CONFIG_DIRECTORY']
+    end
+
+    def self.schema_versions_dir
+      ENV['CLICKHOUSE_SCHEMA_VERSIONS_DIR']
+    end
+
+    def self.database_file
+      ENV['CLICKHOUSE_DATABASE_FILE']
+    end
+
+    def self.raw_config_file_exists?
+      File.exist?(raw_config_file)
+    end
+
+    def self.raw_config_file
+      File.join(config_directory, database_file)
+    end
+
+    def self.raw_config
+      @@raw_config ||= ActiveSupport::ConfigurationFile.parse(raw_config_file).deep_symbolize_keys
+    end
+
+    def self.production_databases
+      @@production_databases ||= raw_config[:production]
+    end
+
+    def self.configure_databases
+      if production_databases.empty?
+        log 'NOTICE: ClickHouse does not have any production databases configured.'
+        return true
+      end
+
+      # This is mostly copied as-is from the ClickHouse initializer in the Rails codebase and the README
+      # of the click_house-client Ruby gem
+      # https://gitlab.com/gitlab-org/gitlab/blob/f4cfdeef153623a826f1bec300b89bfe88d2d70e/config/initializers/click_house.rb#L3-3
+      # https://gitlab.com/gitlab-org/ruby/gems/clickhouse-client
+      ::ClickHouse::Client.configure do |config|
+        production_databases.each do |db_identifier, db_config|
+          log "INFO: Configuring ClickHouse DB #{db_identifier}"
+          config.register_database(db_identifier,
+                                   database: db_config[:database],
+                                   url: db_config[:url],
+                                   username: db_config[:username],
+                                   password: db_config[:password],
+                                   variables: db_config[:variables] || {}
+          )
+
+          # Use any HTTP client to build the POST request, here we use Net::HTTP
+          config.http_post_proc = lambda { |url, headers, body|
+            # Query placeholders go to the URI
+            params = URI.encode_www_form(body.except('query'))
+
+            uri = URI.parse("#{url}&#{params}")
+            request = Net::HTTP::Post.new(uri)
+
+            headers.each do |header, value|
+              request[header] = value
+            end
+
+            request['Content-type'] = 'application/x-www-form-urlencoded'
+            request.body = body['query']
+
+            response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+              http.request(request)
+            end
+
+            ::ClickHouse::Client::Response.new(response.body, response.code.to_i, response.each_header.to_h)
+          }
+        end
+      end
+    end
+
+    class DatabaseConfig
+      include Checks::BypassSchemaVersionCheck
+
+      def initialize(db_identifier, table_name = 'schema_migrations')
+        @db_identifier = db_identifier
+        @table_name = table_name
+      end
+
+      def log(msg)
+        Checks::ClickHouse.log(msg)
+      end
+
+      def check_schema_version
+        log "INFO: ClickHouse - Database #{db_identifier}"
+
+        fetched_database_versions = database_schema_versions
+        log 'NOTICE: Database has not been initialized yet.' if @database_versions.empty?
+
+        pending_migrations = (Set.new(codebase_schema_versions) - Set.new(@database_versions)).length
+        log "INFO: There are #{pending_migrations} migrations pending."
+
+        log 'FATAL: Database versions could not be fetched' unless fetched_database_versions
+        return false unless fetched_database_versions
+
+        if fetched_database_versions && bypass_clickhouse_schema_version_check
+          log "INFO: Schema version check bypassed by #{BYPASS_CLICKHOUSE_SCHEMA_VERSION_KEY}='#{ENV[BYPASS_CLICKHOUSE_SCHEMA_VERSION_KEY]}'"
+          return true
+        end
+
+        fetched_database_versions && pending_migrations.zero?
+      rescue StandardError => e
+        log "FATAL: Error while checking schema versions for ClickHouse #{db_identifier} DB: #{e.message}"
+        false
+      end
+
+      private
+
+      def codebase_schema_versions
+        Dir.glob("#{Checks::ClickHouse.schema_versions_dir}/#{db_identifier.to_s}/*").map do |file|
+          File.basename(file, '.rb').split('_').first.to_i
+        end
+      end
+
+      def database_schema_versions
+        @database_versions = []
+
+        # If schema_migrations table does not exist, then the DB has been created but not yet
+        # initialized. Schema check will not fail, allowing migration scripts to run and create
+        # this table.
+        unless table_exists?
+          log 'NOTICE: schema_migrations table does not exist'
+          return true
+        end
+
+        @database_versions = ::ClickHouse::Client.select("SELECT version FROM #{SCHEMA_MIGRATIONS_TABLE}", db_identifier)
+                                                 .map { |v| v['version'].to_i }
+
+        !@database_versions.empty?
+      rescue ::ClickHouse::Client::Error => e
+        # Exception is returned by ClickHouse in JSON format as per the default configuration.
+        # https://clickhouse.com/docs/interfaces/http#valid-output-on-exception-http-streaming
+        begin
+          parsed_error = JSON.parse(e.message)
+          log "FATAL: Error while fetching the database versions for ClickHouse #{db_identifier} DB: #{parsed_error['exception']}"
+        rescue JSON::ParserError
+          log "FATAL: Unexpected error while fetching the database versions for ClickHouse #{db_identifier} DB: #{e.message}"
+        end
+        false
+      end
+
+      # This block is copied as-is from the gitlab-org/gitlab codebase:
+      # https://gitlab.com/gitlab-org/gitlab/blob/fc396a1369fb6562838c2b3e388490989254d979/lib/click_house/connection.rb#L58-59
+      def table_exists?
+        raw_query = <<~SQL.squish
+          SELECT 1 FROM system.tables
+          WHERE name = {table_name: String}
+        SQL
+
+        placeholders = { table_name: table_name }
+
+        query = ::ClickHouse::Client::Query.new(raw_query: raw_query, placeholders: placeholders)
+
+        ::ClickHouse::Client.select(query, db_identifier).any?
+      end
+
+      attr_reader :db_identifier, :db_config, :table_name
+    end
+
+    def self.check_all_databases
+      results = production_databases.keys.map do |db_identifier|
+        Thread.new do
+          log "INFO: Checking migration schema state for ClickHouse database #{db_identifier}"
+          DatabaseConfig.new(db_identifier).check_schema_version
+        end
+      end.map(&:value)
+
+      # Collect the checks that passed.
+      results.all?
+    end
+
+    LOG_PREFIX = 'ClickHouse'
+
+    def self.log(msg)
+      puts "[#{LOG_PREFIX}] #{msg}"
+    end
+  end
+end

--- a/chart/gitlab/config/files/dhi-gitlab-cng/lib/checks/postgresql.rb
+++ b/chart/gitlab/config/files/dhi-gitlab-cng/lib/checks/postgresql.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+require 'yaml'
+require 'active_record'
+
+module Checks
+  # Perform checks of PostgreSQL dependency.
+  # Usage: `Checks::PostgreSQL.run`
+  module PostgreSQL
+    def self.run
+      counter = 1
+      passed = false
+      until (counter == wait_for_timeout) || passed
+        passed = check_all_databases
+        sleep sleep_duration unless passed
+        counter += 1
+      end
+      passed
+    end
+
+    def self.wait_for_timeout
+      ENV['WAIT_FOR_TIMEOUT'].to_i
+    end
+
+    def self.sleep_duration
+      ENV['SLEEP_DURATION'].to_i
+    end
+
+    def self.config_directory
+      ENV['CONFIG_DIRECTORY']
+    end
+
+    def self.schema_versions_dir
+      ENV['SCHEMA_VERSIONS_DIR']
+    end
+
+    def self.database_file
+      ENV['DATABASE_FILE']
+    end
+
+    def self.db_schema_target
+      ENV['DB_SCHEMA_TARGET']
+    end
+
+    class DatabaseConfig
+      include Checks::BypassSchemaVersionCheck
+
+      def initialize(shard_name)
+        @shard_name = shard_name
+      end
+
+      def check_schema_version
+        success = database_schema_version
+
+        puts "Database Schema - #{@shard_name} (#{ActiveRecord::Base.connection_db_config.database})"
+        puts 'NOTICE: Database has not been initialized yet.' if @database_versions.empty?
+        if bypass_schema_version_check
+          puts "WARNING: schema version check bypassed by #{BYPASS_SCHEMA_VERSION_KEY}='#{ENV[BYPASS_SCHEMA_VERSION_KEY]}'"
+        end
+        pending_migrations = (Set.new(codebase_schema_versions) - Set.new(@database_versions)).length
+        puts "NOTICE: There are #{pending_migrations} pending migrations." if pending_migrations > 0
+
+        return true if bypass_schema_version_check && success
+
+        success && !(pending_migrations > 0)
+      rescue StandardError => e
+        puts "Error checking #{@shard_name}: #{e.message}"
+        false
+      end
+
+      private
+
+      def database_schema_version
+        db_config = ActiveRecord::Base.configurations.configs_for(env_name: 'production', name: @shard_name)
+        connection = ActiveRecord::Base.establish_connection(db_config).lease_connection
+        schema_migrations_table_name = ActiveRecord::Base.schema_migrations_table_name
+
+        # if connection is bad, we will get an error (rescue below)
+        # if table exists, fetch versions.
+        table_exists = connection.table_exists?(schema_migrations_table_name)
+        @database_versions = []
+
+        if table_exists
+          @database_versions =
+            connection.select_values("SELECT version FROM #{schema_migrations_table_name}").map(&:to_i)
+        end
+
+        if @database_versions.empty?
+          puts "WARNING: Problem accessing #{@shard_name} database (#{ActiveRecord::Base.connection_db_config.database})."\
+               ' Confirm username, password, and permissions.'
+        end
+
+        # Returning false prevents bailing when BYPASS_SCHEMA_VERSION set.
+        return !@database_versions.empty? if table_exists
+
+        true
+      rescue RuntimeError => e
+        puts "Error fetching #{@shard_name} schema: #{e.message}"
+        false
+      end
+
+      def codebase_schema_versions
+        Dir.glob("#{Checks::PostgreSQL.schema_versions_dir}/*").map do |file|
+          File.basename(file, '.rb').split('_').first.to_i
+        end
+      end
+    end
+
+    def self.database_configurations
+      @@database_configurations ||= ActiveRecord::DatabaseConfigurations
+                                    .new(database_yaml)
+    end
+
+    def self.database_yaml
+      @@database_yaml ||= ActiveSupport::ConfigurationFile.parse(
+        File.join(config_directory, database_file)
+      )
+    end
+
+    def self.production_databases
+      db_configs = database_configurations.configs_for(
+        env_name: 'production', include_hidden: false
+      )
+                                          # we filter out the embedding DB as it's schema only
+                                          # receives selected migrations and will lag behind
+                                          .reject { |db_config| db_config.name == 'embedding' }
+
+      db_configs =
+        if db_schema_target == 'geo'
+          # TODO: To be removed in 15.0. See https://gitlab.com/gitlab-org/gitlab/-/issues/351946
+          # The db_config.name is set to primary when config/database_geo.yml exists and uses a legacy syntax.
+          db_configs.find { |db_config| %w[primary geo].include?(db_config.name) }
+        else
+          db_configs.reject { |db_config| db_config.name == 'geo' }
+        end
+
+      Array(db_configs)
+    end
+
+    def self.check_all_databases
+      ActiveRecord::Base.configurations = database_configurations
+
+      puts "Checking: #{production_databases.map(&:name).join(', ')}"
+
+      results = production_databases.map do |db_config|
+        Thread.new do
+          DatabaseConfig.new(db_config.name).check_schema_version
+        end
+      end.map(&:value)
+
+      # Collect the checks that passed.
+      results.all?
+    end
+  end
+end

--- a/chart/gitlab/config/files/dhi-gitlab-cng/lib/checks/redis.rb
+++ b/chart/gitlab/config/files/dhi-gitlab-cng/lib/checks/redis.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'yaml'
+require 'redis'
+# Get Hash.deep_symbolize_keys from Rails
+# - allows transparent transformation of Sentinel configuration
+require 'active_support/core_ext/hash/keys'
+
+module Checks
+  # Perform checks of Redis dependency.
+  # Usage: `Checks::Redis.run`
+  module Redis
+    def self.run
+      counter = 1
+      passed = false
+      until (counter == wait_for_timeout) || passed
+        passed = check_redis_connectivity
+        sleep sleep_duration unless passed
+        counter += 1
+      end
+      passed
+    end
+
+    def self.config_directory
+      ENV['CONFIG_DIRECTORY'].to_s
+    end
+
+    def self.wait_for_timeout
+      ENV['WAIT_FOR_TIMEOUT'].to_i
+    end
+
+    def self.sleep_duration
+      ENV['SLEEP_DURATION'].to_i
+    end
+
+    def self.redis_config(file)
+      resque_yaml = YAML.load_file(File.join(config_directory, file))
+      prod_config = resque_yaml['production'].deep_symbolize_keys
+      prod_config.except(:adapter, :channel_prefix) # for compatibility with redis v5
+    end
+
+    def self.ping_redis(file)
+      redis = ::Redis.new(redis_config(file))
+      url = if Gem::Version.new(::Redis::VERSION) >= Gem::Version.new(5)
+              redis._client.config.server_url
+            else
+              "#{redis._client.scheme}://#{redis._client.host}:#{redis._client.port}"
+            end
+      begin
+        redis.ping
+      rescue RuntimeError, SystemCallError => e
+        puts "- FAILED connecting to '#{url}' from #{file}, through #{redis._client.host}\r\nERROR: #{e.message}"
+        false
+      else
+        redis.disconnect!
+        puts "+ SUCCESS connecting to '#{url}' from #{file}, through #{redis._client.host}"
+        true
+      end
+    end
+
+    def self.check_redis_connectivity
+      files = Dir.glob(['resque.yml', "redis\..*.yml", 'cable.yml'], base: config_directory)
+      puts "Checking: #{files.join(', ')}"
+      results = files.map do |resque_file|
+        Thread.new { Redis.ping_redis(resque_file) }
+      end.map(&:value)
+
+      # Collect the checks that passed.
+      checks_passed = results.select { |r| r }
+      # Return pass/fail based on all checks passing
+      checks_passed.count == files.count
+    end
+  end
+end

--- a/chart/gitlab/config/files/dhi-gitlab-cng/lib/checks/topology_service.rb
+++ b/chart/gitlab/config/files/dhi-gitlab-cng/lib/checks/topology_service.rb
@@ -1,0 +1,208 @@
+# frozen_string_literal: true
+
+require 'yaml'
+require 'grpc'
+require 'active_support/configuration_file'
+require 'gitlab/cells/topology_service'
+
+module Checks
+  # Perform checks of Topology Service dependency for GitLab Cells.
+  # Usage: `Checks::TopologyService.run`
+  module TopologyService
+    LOG_PREFIX = "TopologyService"
+
+    class TopologyServiceConfigurationError < StandardError; end
+    class TopologyServiceUnavailableError < StandardError; end
+
+    def self.run
+      if skip_check?
+        log 'INFO: Topology service check is disabled (SKIP_TOPOLOGY_SERVICE_CHECK != false). Skipping.'
+        return true
+      end
+
+      unless cells_enabled?
+        log 'INFO: Cells not enabled. Skipping topology service check.'
+        return true
+      end
+
+      check_topology_service
+    end
+
+    # Check is disabled by default for safe rollout.
+    # Set SKIP_TOPOLOGY_SERVICE_CHECK=false to enable the check.
+    def self.skip_check?
+      ENV.fetch('SKIP_TOPOLOGY_SERVICE_CHECK', 'true') != 'false'
+    end
+
+    def self.config_directory
+      ENV['CONFIG_DIRECTORY'].to_s
+    end
+
+    def self.wait_for_timeout
+      ENV['WAIT_FOR_TIMEOUT'].to_i
+    end
+
+    def self.sleep_duration
+      ENV['SLEEP_DURATION'].to_i
+    end
+
+    def self.gitlab_config
+      @gitlab_config ||= ActiveSupport::ConfigurationFile.parse(
+        File.join(config_directory, 'gitlab.yml')
+      )
+    end
+
+    def self.cell_config
+      gitlab_config.dig('production', 'cell') || {}
+    end
+
+    def self.cells_enabled?
+      cell_config['enabled'] == true
+    end
+
+    def self.cell_id
+      cell_config['id']
+    end
+
+    def self.topology_service_config
+      cell_config['topology_service_client'] || {}
+    end
+
+    def self.topology_service_address
+      topology_service_config['address']
+    end
+
+    def self.tls_enabled?
+      topology_service_config.dig('tls', 'enabled') == true
+    end
+
+    def self.grpc_timeout
+      ENV.fetch('TOPOLOGY_SERVICE_GRPC_TIMEOUT', 5).to_i
+    end
+
+    def self.secrets_directory
+      ENV.fetch('GITLAB_SECRETS_DIR', '/etc/gitlab')
+    end
+
+    def self.resolve_cert_path(configured_path)
+      return configured_path if configured_path && File.readable?(configured_path)
+
+      return unless configured_path
+
+      basename = File.basename(configured_path)
+      dirname = File.basename(File.dirname(configured_path))
+      fallback = File.join(secrets_directory, dirname, basename)
+
+      if File.readable?(fallback)
+        log "INFO: Certificate not found at #{configured_path}, using fallback #{fallback}"
+        return fallback
+      end
+
+      log "WARN: Certificate not found at #{configured_path} or fallback #{fallback}"
+      nil
+    end
+
+    def self.service_credentials
+      return :this_channel_is_insecure unless tls_enabled?
+
+      ca_file = resolve_cert_path(topology_service_config['ca_file'])
+      key_file = resolve_cert_path(topology_service_config['private_key_file'])
+      cert_file = resolve_cert_path(topology_service_config['certificate_file'])
+
+      unless key_file && cert_file
+        log "WARN: mTLS key/cert files not found, falling back to server-only TLS"
+        return GRPC::Core::ChannelCredentials.new
+      end
+
+      ca_cert = ca_file ? File.read(ca_file) : nil
+      GRPC::Core::ChannelCredentials.new(ca_cert, File.read(key_file), File.read(cert_file))
+    rescue Errno::EACCES, Errno::ENOENT => e
+      log "ERROR: Failed to read certificate files: #{e.message}"
+      raise
+    end
+
+    def self.check_topology_service
+      address = topology_service_address
+      unless address
+        log 'ERROR: Topology service address not configured'
+        log 'ERROR: Configuration error - this is a hard failure. Cannot proceed.'
+        return false
+      end
+
+      log "INFO: Checking topology service at #{address}"
+
+      attempt = 1
+      max_attempts = wait_for_timeout
+
+      loop do
+        result = attempt_cell_check(address)
+
+        # Hard failure - stop immediately
+        return false if result == false
+
+        # Success - we're done
+        if result == true
+          log 'INFO: Cell validation passed'
+          return true
+        end
+
+        # Soft failure (nil) - retry if we have attempts left
+        attempt += 1
+        if attempt > max_attempts
+          log 'WARN: Topology service unavailable after retries. Proceeding with soft failure.'
+          log 'WARN: This may affect ~5% of operations (write operations requiring topology service).'
+          return true
+        end
+
+        log "INFO: Retrying... (attempt #{attempt}/#{max_attempts})"
+        sleep sleep_duration
+      end
+    end
+
+    def self.attempt_cell_check(address)
+      check_cell!(address)
+      true
+    rescue TopologyServiceConfigurationError => e
+      log "ERROR: #{e.message}"
+      log 'ERROR: Configuration error - this is a hard failure. Cannot proceed.'
+      false
+    rescue TopologyServiceUnavailableError => e
+      log "WARN: #{e.message}"
+      nil
+    rescue StandardError => e
+      log "WARN: Unexpected error: #{e.class} - #{e.message}"
+      nil # Treat as soft failure, allow retry
+    end
+
+    def self.check_cell!(address)
+      raise TopologyServiceConfigurationError, 'Cell ID not configured' unless cell_id
+
+      stub = Gitlab::Cells::TopologyService::CellService::Stub.new(address, service_credentials)
+      request = Gitlab::Cells::TopologyService::GetCellRequest.new(cell_id: cell_id)
+      response = stub.get_cell(request, deadline: Time.now + grpc_timeout)
+
+      cell_info = response.cell_info
+      raise TopologyServiceConfigurationError, "Cell '#{cell_id}' returned no cell info" unless cell_info
+
+      if cell_info.id.to_s != cell_id.to_s
+        raise TopologyServiceConfigurationError, "Cell ID mismatch. Expected: #{cell_id}, Got: #{cell_info.id}"
+      end
+
+      log "INFO: Cell '#{cell_id}' validated (address: #{cell_info.address})"
+    rescue GRPC::NotFound
+      raise TopologyServiceConfigurationError, "Cell '#{cell_id}' not found in topology service"
+    rescue GRPC::Unavailable => e
+      raise TopologyServiceUnavailableError, "GetCell request failed - service unavailable: #{e.message}"
+    rescue GRPC::DeadlineExceeded
+      raise TopologyServiceUnavailableError, 'GetCell request timed out'
+    rescue GRPC::PermissionDenied, GRPC::Unauthenticated => e
+      raise TopologyServiceConfigurationError, "Authentication/authorization failed (check mTLS certificates): #{e.message}"
+    rescue GRPC::BadStatus => e
+      raise TopologyServiceUnavailableError, "GetCell request failed: #{e.class} - #{e.message}"
+    end
+
+    def self.log(msg)
+      puts "[#{LOG_PREFIX}] #{msg}"
+    end
+  end
+end

--- a/chart/gitlab/config/files/dhi-gitlab-cng/rails-dependencies
+++ b/chart/gitlab/config/files/dhi-gitlab-cng/rails-dependencies
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Ensure output is not buffered
+$stdout.sync = true
+$stderr.sync = true
+
+# Get this scripts own path, so we can require
+lib_path = File.dirname(File.expand_path($PROGRAM_NAME))
+app_path = '/srv/gitlab'
+
+# change to the application directory
+Dir.chdir(app_path)
+
+# Setup the use of Bundler installed gems
+require "#{app_path}/config/bundler_setup"
+
+# pull in our libraries
+require "#{lib_path}/lib/bypass_schema_version_check"
+require "#{lib_path}/lib/checks/postgresql"
+require "#{lib_path}/lib/checks/redis"
+require "#{lib_path}/lib/checks/clickhouse"
+require "#{lib_path}/lib/checks/topology_service"
+
+database_thread = Thread.new do
+  Checks::PostgreSQL.run
+end
+
+redis_thread = Thread.new do
+  Checks::Redis.run
+end
+
+clickhouse_thread = Thread.new do
+  Checks::ClickHouse.run
+end
+
+topology_service_thread = Thread.new do
+  Checks::TopologyService.run
+end
+
+[database_thread, redis_thread, clickhouse_thread, topology_service_thread].map(&:join)
+
+if redis_thread.value && database_thread.value && clickhouse_thread.value && topology_service_thread.value
+  Bundler.original_exec ARGV.join(' ') unless ARGV.empty?
+else
+  puts 'WARNING: Not all services were operational, with data migrations completed.'
+
+  # Output a message as to how to resolve this container failing.
+  puts 'If this container continues to fail, please see: https://docs.gitlab.com/charts/troubleshooting/index.html#application-containers-constantly-initializing'
+
+  exit 1
+end

--- a/chart/gitlab/config/files/dhi-gitlab-cng/wait-for-deps
+++ b/chart/gitlab/config/files/dhi-gitlab-cng/wait-for-deps
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+cd /srv/gitlab
+
+WAIT_FOR_TIMEOUT="${WAIT_FOR_TIMEOUT:-30}"
+SLEEP_DURATION="${SLEEP_DURATION:-1}"
+
+DATABASE_FILE=database.yml
+SCHEMA_DIR=db
+SCHEMA_MIGRATIONS_DIR=schema_migrations
+
+# Allow skipping database post-migrations in version checks
+## This will cause the codebase version to be pulled from the
+## latest entry in `migrate/` instead of `schema_migrations/`
+if [ -n "${BYPASS_POST_DEPLOYMENT}" ]; then
+  SCHEMA_MIGRATIONS_DIR=migrate
+  echo "NOTICE: Bypassing post-migrations for database version checks"
+fi
+
+# Allow for re-direction to the Geo database
+if [ "${DB_SCHEMA_TARGET,,}" == "geo" ]; then
+  SCHEMA_DIR=ee/db/geo
+
+  # Retain support for older database file if needed
+  if [ -f "config/database_geo.yml" ]; then
+    DATABASE_FILE=database_geo.yml
+  fi
+fi
+
+# set the desired directory to retrieve schema versions
+SCHEMA_VERSIONS_DIR="$(pwd)/${SCHEMA_DIR}/${SCHEMA_MIGRATIONS_DIR}"
+
+CLICKHOUSE_SCHEMA_VERSIONS_DIR="$(pwd)/${SCHEMA_DIR}/click_house/${SCHEMA_MIGRATIONS_DIR}"
+CLICKHOUSE_DATABASE_FILE=click_house.yml
+
+# export variables for rails-dependencies
+export WAIT_FOR_TIMEOUT
+export SLEEP_DURATION
+export SCHEMA_VERSIONS_DIR
+export CLICKHOUSE_SCHEMA_VERSIONS_DIR
+export CLICKHOUSE_DATABASE_FILE
+export DB_SCHEMA_TARGET
+export DATABASE_FILE
+
+# the called script should `exec` the arguments passed to this script
+exec /opt/gitlab/cng-scripts/rails-dependencies "$@"

--- a/chart/gitlab/config/gitlab-dhi-runtime.patch
+++ b/chart/gitlab/config/gitlab-dhi-runtime.patch
@@ -1,0 +1,111 @@
+diff --git a/charts/gitlab/charts/gitlab-exporter/templates/deployment.yaml b/charts/gitlab/charts/gitlab-exporter/templates/deployment.yaml
+index 094002f..2ec6084 100644
+--- a/charts/gitlab/charts/gitlab-exporter/templates/deployment.yaml
++++ b/charts/gitlab/charts/gitlab-exporter/templates/deployment.yaml
+@@ -92,0 +93,8 @@ spec:
++          command: ["/bin/sh", "-c"]
++          args:
++            - |
++              set -e
++              ruby -rerb -ryaml -e 'File.write(ARGV[1], ERB.new(File.read(ARGV[0])).result)' \
++                /var/opt/gitlab-exporter/templates/gitlab-exporter.yml.erb \
++                /tmp/gitlab-exporter.yml
++              exec /usr/local/bin/gitlab-exporter web -c /tmp/gitlab-exporter.yml
+diff --git a/charts/gitlab/charts/gitlab-shell/templates/configmap.yml b/charts/gitlab/charts/gitlab-shell/templates/configmap.yml
+index d5d5127..58c56a4 100644
+--- a/charts/gitlab/charts/gitlab-shell/templates/configmap.yml
++++ b/charts/gitlab/charts/gitlab-shell/templates/configmap.yml
+@@ -21 +21 @@ data:
+-  config.yml.tpl: |
++  config.yml: |
+@@ -89,5 +89,3 @@ data:
+-      {%- range file.Walk ( env.Getenv "KEYS_DIRECTORY" "/etc/ssh" ) %}
+-        {%- if filepath.Base . | filepath.Match "ssh_host_*_key" %}
+-        - {%.%}
+-        {%- end %}
+-      {%- end %}
++        - /etc/gitlab-secrets/ssh/ssh_host_rsa_key
++        - /etc/gitlab-secrets/ssh/ssh_host_ecdsa_key
++        - /etc/gitlab-secrets/ssh/ssh_host_ed25519_key
+diff --git a/charts/gitlab/charts/gitlab-shell/templates/deployment.yaml b/charts/gitlab/charts/gitlab-shell/templates/deployment.yaml
+index e98def9..bf0cb85 100644
+--- a/charts/gitlab/charts/gitlab-shell/templates/deployment.yaml
++++ b/charts/gitlab/charts/gitlab-shell/templates/deployment.yaml
+@@ -118,0 +119,4 @@ spec:
++            - name: shell-config
++              mountPath: /srv/gitlab-shell/config.yml
++              subPath: config.yml
++              readOnly: true
+diff --git a/charts/gitlab/charts/sidekiq/templates/deployment.yaml b/charts/gitlab/charts/sidekiq/templates/deployment.yaml
+index 4cd2191..beeae15 100644
+--- a/charts/gitlab/charts/sidekiq/templates/deployment.yaml
++++ b/charts/gitlab/charts/sidekiq/templates/deployment.yaml
+@@ -156 +156 @@ spec:
+-            - /scripts/wait-for-deps
++            - /opt/gitlab/cng-scripts/wait-for-deps
+@@ -193,0 +194,14 @@ spec:
++          command: ["/scripts/entrypoint.sh"]
++          args:
++            - /bin/bash
++            - -c
++            - |
++              set -e
++              touch /var/log/gitlab/production.log
++              cd /srv/gitlab
++              exec bin/sidekiq-cluster \
++                -r /srv/gitlab \
++                -e production \
++                -c "${SIDEKIQ_CONCURRENCY:-20}" \
++                -t "$SIDEKIQ_TIMEOUT" \
++                "${SIDEKIQ_QUEUES:-*}"
+diff --git a/charts/gitlab/charts/webservice/templates/configmap.yml b/charts/gitlab/charts/webservice/templates/configmap.yml
+index 873eb99..832fae6 100644
+--- a/charts/gitlab/charts/webservice/templates/configmap.yml
++++ b/charts/gitlab/charts/webservice/templates/configmap.yml
+@@ -214 +214 @@ data:
+-  workhorse-config.toml.tpl: |
++  workhorse-config.toml: |
+@@ -234 +233,0 @@ data:
+-    {{- include "workhorse.object_storage.config" $ | nindent 4 }}
+diff --git a/charts/gitlab/charts/webservice/templates/deployment.yaml b/charts/gitlab/charts/webservice/templates/deployment.yaml
+index 6dac90b..ce302fd 100644
+--- a/charts/gitlab/charts/webservice/templates/deployment.yaml
++++ b/charts/gitlab/charts/webservice/templates/deployment.yaml
+@@ -159 +159 @@ spec:
+-            - /scripts/wait-for-deps
++            - /opt/gitlab/cng-scripts/wait-for-deps
+@@ -406,0 +407,4 @@ spec:
++            - name: workhorse-config
++              mountPath: /srv/gitlab/config/workhorse-config.toml
++              subPath: workhorse-config.toml
++              readOnly: true
+diff --git a/charts/gitlab/charts/webservice/templates/tests/test-runner.yaml b/charts/gitlab/charts/webservice/templates/tests/test-runner.yaml
+index e7b6667..20a518e 100644
+--- a/charts/gitlab/charts/webservice/templates/tests/test-runner.yaml
++++ b/charts/gitlab/charts/webservice/templates/tests/test-runner.yaml
+@@ -1,0 +2 @@
++{{- $imageCfg := dict "global" $.Values.global.image "local" $.Values.global.gitlabBase.image -}}
+@@ -13,0 +15 @@ spec:
++  {{- include "gitlab.image.pullSecrets" $imageCfg | indent 2 }}
+@@ -16 +18 @@ spec:
+-    image: {{ include "webservice.image" . }}
++    image: {{ include "gitlab.configure.image" (dict "root" $ "image" .Values.init.image) | quote }}
+diff --git a/templates/_certificates.tpl b/templates/_certificates.tpl
+index df42f6d..29a0d34 100644
+--- a/templates/_certificates.tpl
++++ b/templates/_certificates.tpl
+@@ -10,0 +11,14 @@
++  command: ["/bin/sh", "-c"]
++  args:
++    - |
++      set -e
++      rm -rf /etc/ssl/certs/*
++      update-ca-certificates
++      for certificate in /etc/ssl/certs/*.pem /etc/ssl/certs/*.crt; do
++        [ -e "$certificate" ] || continue
++        origin="$(readlink -f "$certificate")"
++        if [ "${origin%/*}" != /etc/ssl/certs ]; then
++          rm "$certificate"
++          cp "$origin" "$certificate"
++        fi
++      done

--- a/chart/gitlab/config/templates/dhi-gitlab-cng-scripts.yaml
+++ b/chart/gitlab/config/templates/dhi-gitlab-cng-scripts.yaml
@@ -1,0 +1,26 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-dhi-gitlab-cng-scripts
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "gitlab.standardLabels" . | nindent 4 }}
+data:
+  wait-for-deps: |
+{{ .Files.Get "files/dhi-gitlab-cng/wait-for-deps" | indent 4 }}
+  rails-dependencies: |
+{{ .Files.Get "files/dhi-gitlab-cng/rails-dependencies" | indent 4 }}
+  db-migrate: |
+{{ .Files.Get "files/dhi-gitlab-cng/db-migrate" | indent 4 }}
+  custom-instance-setup: |
+{{ .Files.Get "files/dhi-gitlab-cng/custom-instance-setup" | indent 4 }}
+  bypass_schema_version_check.rb: |
+{{ .Files.Get "files/dhi-gitlab-cng/lib/bypass_schema_version_check.rb" | indent 4 }}
+  clickhouse.rb: |
+{{ .Files.Get "files/dhi-gitlab-cng/lib/checks/clickhouse.rb" | indent 4 }}
+  postgresql.rb: |
+{{ .Files.Get "files/dhi-gitlab-cng/lib/checks/postgresql.rb" | indent 4 }}
+  redis.rb: |
+{{ .Files.Get "files/dhi-gitlab-cng/lib/checks/redis.rb" | indent 4 }}
+  topology_service.rb: |
+{{ .Files.Get "files/dhi-gitlab-cng/lib/checks/topology_service.rb" | indent 4 }}

--- a/chart/gitlab/config/values.yaml
+++ b/chart/gitlab/config/values.yaml
@@ -1,0 +1,239 @@
+global:
+  edition: ce
+  hosts:
+    domain: example.invalid
+  gatewayApi:
+    enabled: false
+    installEnvoy: false
+    configureCertmanager: false
+  ingress:
+    enabled: false
+    configureCertmanager: false
+    tls:
+      enabled: true
+      secretName: gitlab-tls
+  appConfig:
+    artifacts:
+      connection:
+        secret: gitlab-object-storage
+        key: connection
+    lfs:
+      connection:
+        secret: gitlab-object-storage
+        key: connection
+    uploads:
+      connection:
+        secret: gitlab-object-storage
+        key: connection
+    packages:
+      connection:
+        secret: gitlab-object-storage
+        key: connection
+  psql:
+    host: postgresql.example.invalid
+    port: 5432
+    username: gitlab
+    database: gitlabhq_production
+    password:
+      useSecret: true
+      secret: gitlab-postgresql-password
+      key: password
+  redis:
+    host: redis.example.invalid
+    port: 6379
+    auth:
+      enabled: true
+      secret: gitlab-redis-password
+      key: password
+  gitaly:
+    enabled: false
+    external:
+      - name: default
+        hostname: gitaly.example.invalid
+        port: 8075
+    authToken:
+      secret: gitlab-gitaly-token
+      key: token
+  kas:
+    enabled: false
+  pages:
+    enabled: false
+  registry:
+    enabled: false
+  railsSecrets:
+    secret: gitlab-rails-secret
+  shell:
+    authToken:
+      secret: gitlab-shell-secret
+      key: secret
+  workhorse:
+    secret: gitlab-workhorse-secret
+    key: shared_secret
+  initialRootPassword:
+    secret: gitlab-initial-root-password
+    key: password
+  gitlabBase:
+    image:
+      repository: ${bash.registry}/${bash.repository}
+      tag: ${bash.tag}@${bash.digest}
+  certificates:
+    image:
+      repository: ${bash.registry}/${bash.repository}
+      tag: ${bash.tag}@${bash.digest}
+    customCAs: []
+
+installCertmanager: false
+
+prometheus:
+  install: false
+
+gitlab-runner:
+  install: false
+
+nginx-ingress:
+  enabled: false
+
+nginx-ingress-geo:
+  enabled: false
+
+traefik:
+  install: false
+
+haproxy:
+  install: false
+
+gitlab-zoekt:
+  install: false
+
+openbao:
+  install: false
+
+ai-gateway:
+  install: false
+
+registry:
+  enabled: false
+
+shared-secrets:
+  enabled: false
+
+upgradeCheck:
+  enabled: false
+
+gitlab:
+  webservice:
+    image:
+      repository: ${gitlab-webservice.registry}/${gitlab-webservice.repository}
+      tag: ${gitlab-webservice.tag}@${gitlab-webservice.digest}
+    workhorse:
+      image: ${gitlab-workhorse.registry}/${gitlab-workhorse.repository}
+      tag: ${gitlab-workhorse.tag}@${gitlab-workhorse.digest}
+      keywatcher: false
+    extraVolumes: |
+      - name: dhi-gitlab-cng-scripts
+        configMap:
+          name: {{ $.Release.Name }}-dhi-gitlab-cng-scripts
+          defaultMode: 0555
+          items:
+            - key: wait-for-deps
+              path: wait-for-deps
+            - key: rails-dependencies
+              path: rails-dependencies
+            - key: db-migrate
+              path: db-migrate
+            - key: custom-instance-setup
+              path: custom-instance-setup
+            - key: bypass_schema_version_check.rb
+              path: lib/bypass_schema_version_check.rb
+            - key: clickhouse.rb
+              path: lib/checks/clickhouse.rb
+            - key: postgresql.rb
+              path: lib/checks/postgresql.rb
+            - key: redis.rb
+              path: lib/checks/redis.rb
+            - key: topology_service.rb
+              path: lib/checks/topology_service.rb
+    extraVolumeMounts: |
+      - name: dhi-gitlab-cng-scripts
+        mountPath: /opt/gitlab/cng-scripts
+        readOnly: true
+  sidekiq:
+    image:
+      repository: ${gitlab-webservice.registry}/${gitlab-webservice.repository}
+      tag: ${gitlab-webservice.tag}@${gitlab-webservice.digest}
+    extraVolumes: |
+      - name: dhi-gitlab-cng-scripts
+        configMap:
+          name: {{ $.Release.Name }}-dhi-gitlab-cng-scripts
+          defaultMode: 0555
+          items:
+            - key: wait-for-deps
+              path: wait-for-deps
+            - key: rails-dependencies
+              path: rails-dependencies
+            - key: db-migrate
+              path: db-migrate
+            - key: custom-instance-setup
+              path: custom-instance-setup
+            - key: bypass_schema_version_check.rb
+              path: lib/bypass_schema_version_check.rb
+            - key: clickhouse.rb
+              path: lib/checks/clickhouse.rb
+            - key: postgresql.rb
+              path: lib/checks/postgresql.rb
+            - key: redis.rb
+              path: lib/checks/redis.rb
+            - key: topology_service.rb
+              path: lib/checks/topology_service.rb
+    extraVolumeMounts: |
+      - name: dhi-gitlab-cng-scripts
+        mountPath: /opt/gitlab/cng-scripts
+        readOnly: true
+  migrations:
+    image:
+      repository: ${gitlab-webservice.registry}/${gitlab-webservice.repository}
+      tag: ${gitlab-webservice.tag}@${gitlab-webservice.digest}
+    scriptTpl: |
+      set -e
+      /opt/gitlab/cng-scripts/wait-for-deps
+      /opt/gitlab/cng-scripts/db-migrate
+    extraVolumes: |
+      - name: dhi-gitlab-cng-scripts
+        configMap:
+          name: {{ $.Release.Name }}-dhi-gitlab-cng-scripts
+          defaultMode: 0555
+          items:
+            - key: wait-for-deps
+              path: wait-for-deps
+            - key: rails-dependencies
+              path: rails-dependencies
+            - key: db-migrate
+              path: db-migrate
+            - key: custom-instance-setup
+              path: custom-instance-setup
+            - key: bypass_schema_version_check.rb
+              path: lib/bypass_schema_version_check.rb
+            - key: clickhouse.rb
+              path: lib/checks/clickhouse.rb
+            - key: postgresql.rb
+              path: lib/checks/postgresql.rb
+            - key: redis.rb
+              path: lib/checks/redis.rb
+            - key: topology_service.rb
+              path: lib/checks/topology_service.rb
+    extraVolumeMounts: |
+      - name: dhi-gitlab-cng-scripts
+        mountPath: /opt/gitlab/cng-scripts
+        readOnly: true
+  toolbox:
+    enabled: false
+  gitlab-shell:
+    image:
+      repository: ${gitlab-shell.registry}/${gitlab-shell.repository}
+      tag: ${gitlab-shell.tag}@${gitlab-shell.digest}
+    extraEnv:
+      GITLAB_SHELL_SECRET_FILE: /etc/gitlab-secrets/shell/.gitlab_shell_secret
+  gitlab-exporter:
+    image:
+      repository: ${gitlab-exporter.registry}/${gitlab-exporter.repository}
+      tag: ${gitlab-exporter.tag}@${gitlab-exporter.digest}

--- a/chart/gitlab/guides.md
+++ b/chart/gitlab/guides.md
@@ -1,0 +1,130 @@
+## Installing the chart
+
+### Prerequisites
+
+Before installing, provide:
+
+- A Kubernetes version supported by the upstream GitLab 10.1 chart and Helm 3.8 or later.
+- Authenticated access to `dhi.io` from every node, normally through an image pull Secret.
+- PostgreSQL and Redis endpoints reachable from the target namespace.
+- An external Gitaly server compatible with GitLab 19.1, including its authentication token.
+- S3-compatible, Google Cloud, or Azure object storage for artifacts, LFS objects, uploads, and packages.
+- An external ingress or Gateway and externally managed TLS certificates.
+- All Kubernetes Secrets listed below. Automatic secret generation is intentionally disabled.
+
+The default `*.example.invalid` endpoints are placeholders and will not connect to real services.
+
+### Required Secrets
+
+Create the required Secrets below before installation. A row explicitly marked optional may be omitted. Use a secret manager
+or your normal GitOps workflow; do not put production credentials directly in a values file.
+
+| Secret | Required key(s) | Purpose |
+| --- | --- | --- |
+| `gitlab-postgresql-password` | `password` | PostgreSQL authentication |
+| `gitlab-redis-password` | `password` | Redis authentication |
+| `gitlab-gitaly-token` | `token` | External Gitaly authentication |
+| `gitlab-object-storage` | `connection` | GitLab object-storage connection YAML |
+| `gitlab-rails-secret` | `secrets.yml` | Rails secret material |
+| `gitlab-shell-secret` | `secret` | GitLab Shell shared secret |
+| `gitlab-workhorse-secret` | `shared_secret` | Workhorse shared secret |
+| `gitlab-initial-root-password` | `password` | Initial administrator password |
+| `gitlab-gitlab-shell-host-keys` | OpenSSH private and public host-key pairs | SSH host identity |
+| `gitlab-registry-secret` | `registry-auth.key` | Rails registry JWT signing key, still consumed when registry serving is disabled |
+| `gitlab-registry-notification` | `secret` | Registry notification secret consumed by Rails |
+| `gitlab-gitlab-runner-secret` | `runner-registration-token` | Optional compatibility token consumed by migration configuration when present; bundled Runner remains disabled |
+
+Follow GitLab's [manual secret documentation](https://docs.gitlab.com/charts/installation/secrets/) for formats and
+cryptographically secure generation. Secret names and keys may be changed through the corresponding upstream values.
+
+### Configure external services
+
+Create a values file that overrides endpoints and deployment-specific settings but leaves the DHI image values intact:
+
+```yaml
+global:
+  hosts:
+    domain: gitlab.example.com
+  image:
+    pullSecrets:
+      - name: helm-pull-secret
+  psql:
+    host: postgresql.database.svc.example.com
+    port: 5432
+    username: gitlab
+    database: gitlabhq_production
+  redis:
+    host: redis.cache.svc.example.com
+    port: 6379
+  gitaly:
+    external:
+      - name: default
+        hostname: gitaly.storage.svc.example.com
+        port: 8075
+  appConfig:
+    artifacts:
+      bucket: gitlab-artifacts
+    lfs:
+      bucket: gitlab-lfs
+    uploads:
+      bucket: gitlab-uploads
+    packages:
+      bucket: gitlab-packages
+```
+
+The `gitlab-object-storage` Secret's `connection` key must contain the provider-specific YAML described in the
+[upstream object-storage documentation](https://docs.gitlab.com/charts/advanced/external-object-storage/).
+
+### Authenticate to Docker Hardened Images
+
+Create an image pull Secret using your Docker credentials:
+
+```console
+kubectl create namespace gitlab
+kubectl -n gitlab create secret docker-registry helm-pull-secret \
+  --docker-server=dhi.io \
+  --docker-username='<Docker username>' \
+  --docker-password='<Docker access token>' \
+  --docker-email='<Docker email>'
+```
+
+See the [DHI Kubernetes authentication guide](https://docs.docker.com/dhi/how-to/k8s/#authentication) for details.
+
+### Install
+
+```console
+helm upgrade --install gitlab oci://dhi.io/gitlab-chart \
+  --version 10.1.6 \
+  --namespace gitlab \
+  --create-namespace \
+  --values gitlab-values.yaml \
+  --timeout 20m
+```
+
+The chart does not create ingress resources by default. Configure your external ingress to route HTTP traffic to the
+Workhorse service and TCP/SSH traffic to the GitLab Shell service, following the upstream GitLab networking guidance.
+
+### Verify
+
+```console
+kubectl -n gitlab get pods,jobs,services
+helm -n gitlab status gitlab
+helm -n gitlab test gitlab
+```
+
+The migration Job must complete before Webservice and Sidekiq become ready. If dependency init containers remain pending,
+verify the external PostgreSQL, Redis, and Gitaly endpoints and their Secrets.
+
+## Hardened-configuration boundaries
+
+Do not enable bundled components merely by changing an `enabled` or `install` value. Unsupported local subcharts retain
+their upstream image defaults and are not part of the DHI image-closure guarantee. Deploy equivalent external services
+separately with hardened images, or extend the chart only after compatible DHI images and runtime validation exist.
+
+In particular, keep these values disabled: `global.gitaly.enabled`, `global.kas.enabled`, `global.pages.enabled`,
+`registry.enabled`, `gitlab.toolbox.enabled`, `shared-secrets.enabled`, `installCertmanager`, `prometheus.install`,
+`gitlab-runner.install`, `nginx-ingress.enabled`, `traefik.install`, `haproxy.install`, `gitlab-zoekt.install`,
+`openbao.install`, `global.gatewayApi.installEnvoy`, and `ai-gateway.install`.
+
+Custom CA injection is supported by the DHI Bash certificate initializer. Supply CA certificates through
+`global.certificates.customCAs` using the upstream Secret or ConfigMap format.

--- a/chart/gitlab/helm/10.yaml
+++ b/chart/gitlab/helm/10.yaml
@@ -1,0 +1,104 @@
+# syntax=dhi.io/build:2-helm3
+
+name: GitLab Helm chart 10.x
+image: dhi.io/gitlab-chart
+variant: helm
+tags:
+  - 10.1.6
+platforms:
+  - linux/amd64
+vars:
+  BASH_REFERENCE: dhi/bash:5.2.37-debian13@sha256:4c4453bad07bb7e5e510b5531aaeeb34ab5aaf62a14993796534845356519a23
+  CHART_COMMIT_SHA: e7cae5d54373da043fcacb75f38848cb92b72da4
+  CHART_HELM_NAME: gitlab-chart
+  DHI_NAMESPACE: dhi
+  DHI_PREFIX: ""
+  DHI_REGISTRY: dhi.io
+  DHI_SKIP_CONTEXT_COPY: "true"
+  GITLAB_EXPORTER_REFERENCE: dhi/gitlab-exporter:16.10.0-debian13@sha256:a795e1d7ff1dcce9d979d6fa175f2bf6e66625a03db07dcecba7c72c41c8f41e
+  GITLAB_SHELL_REFERENCE: dhi/gitlab-shell:14.56.1-debian13@sha256:454ff32bc3989cac5937ac44ae6e0cae84557dd531adbc2b20de0a8d167f3b3e
+  GITLAB_WEBSERVICE_REFERENCE: dhi/gitlab-webservice:19.1.7-debian13@sha256:da3b42b0a9527ba819de2678e4821b8337a792a0eb8e13528688881889a12783
+  GITLAB_WORKHORSE_REFERENCE: dhi/gitlab-workhorse:19.1.6-debian13@sha256:204270e1db691f0d766592d564fd11026bf8561309be736ec3f72705dfbfddaf
+  HELM_VERSION: 4.1.4-2
+  SEMVER_MAJOR_MINOR_VERSION: "10.1"
+  SEMVER_MAJOR_VERSION: "10"
+  SEMVER_VERSION: 10.1.6
+  VERSION: 10.1.6
+contents:
+  repositories:
+    - deb [signed-by=/usr/share/keyrings/dhi-deb-main.gpg] http://dhi.io/deb/debian/main trixie main
+  keyring:
+    - https://dhi.io/keyring/dhi-deb-gpg.D46852F6925E9F71.key
+  builds:
+    - name: gitlab-chart
+      work-dir: ${source.dir}/gitlab-chart
+      contents:
+        packages:
+          - bash
+          - ca-certificates
+          - coreutils
+          - patch
+          - yq-go
+          - helm=4.1.4-2
+        files:
+          - url: git+https://gitlab.com/gitlab-org/charts/gitlab.git#v10.1.6
+            checksum: e7cae5d54373da043fcacb75f38848cb92b72da4
+            path: ${source.dir}/gitlab-chart
+            uid: 0
+            gid: 0
+      pipeline:
+        - name: constrain and adapt chart
+          runs: |
+            set -eux -o pipefail
+
+            # Keep only local upstream dependencies. All externally fetched
+            # optional charts are unsupported and disabled by the DHI defaults.
+            yq -i '.dependencies |= map(select(.repository == null or .repository == ""))' Chart.yaml
+            rm -f Chart.lock
+
+            patch --batch --forward -p1 < "${source.dir}/config/gitlab-dhi-runtime.patch"
+        - name: prepare chart
+          uses: helm/rudder@v1
+          with:
+            chart:
+              appRef: gitlab-webservice
+              description: Docker Hardened Images Helm chart for GitLab
+              images:
+                - name: bash
+                  ref: dhi/bash:5.2.37-debian13@sha256:4c4453bad07bb7e5e510b5531aaeeb34ab5aaf62a14993796534845356519a23
+                - name: gitlab-webservice
+                  ref: dhi/gitlab-webservice:19.1.7-debian13@sha256:da3b42b0a9527ba819de2678e4821b8337a792a0eb8e13528688881889a12783
+                - name: gitlab-workhorse
+                  ref: dhi/gitlab-workhorse:19.1.6-debian13@sha256:204270e1db691f0d766592d564fd11026bf8561309be736ec3f72705dfbfddaf
+                - name: gitlab-shell
+                  ref: dhi/gitlab-shell:14.56.1-debian13@sha256:454ff32bc3989cac5937ac44ae6e0cae84557dd531adbc2b20de0a8d167f3b3e
+                - name: gitlab-exporter
+                  ref: dhi/gitlab-exporter:16.10.0-debian13@sha256:a795e1d7ff1dcce9d979d6fa175f2bf6e66625a03db07dcecba7c72c41c8f41e
+              name: gitlab-chart
+              notes: ${source.dir}/config/NOTES.txt
+              sourceUrl: https://gitlab.com/gitlab-org/charts/gitlab
+            cmd: prepare
+            registry: dhi.io
+        - name: relocate chart
+          uses: helm/rudder@v1
+          with:
+            cmd: patch
+            patches:
+              from: ${source.dir}/config
+            registry: dhi.io
+        - name: lint
+          uses: helm/cmd@v1
+          with:
+            chart: .
+            cmd: lint .
+        - name: package
+          uses: helm/package@v1
+          with:
+            chart: .
+      paths:
+        - type: directory
+          path: ${source.dir}/config
+          uid: 0
+          gid: 0
+          mode: "0644"
+          source: chart/gitlab/config

--- a/chart/gitlab/info.yaml
+++ b/chart/gitlab/info.yaml
@@ -1,0 +1,13 @@
+metadata:
+  display-name: GitLab Helm chart
+  short-description: GitLab DevSecOps platform using Docker Hardened Images and external stateful services
+  featured: false
+  fips-compliant: false
+  fips-modules: []
+  stig-certified: false
+  home-url: https://about.gitlab.com/
+  categories:
+    - integration-and-delivery
+    - developer-tools
+    - security
+  alternatives: []

--- a/chart/gitlab/logo.svg
+++ b/chart/gitlab/logo.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="96" height="96" viewBox="0 0 96 96" fill="none">
+  <rect width="96" height="96" fill="white"/>
+  <svg x="4" y="4" width="88" height="88" viewBox="0 0 36 36">
+    <path d="M2 14l9.38 9v-9l-4-12.28c-.205-.632-1.176-.632-1.38 0z" fill="#e24329"/>
+    <path d="M34 14l-9.38 9v-9l4-12.28c.205-.632 1.176-.632 1.38 0z" fill="#e24329"/>
+    <path d="M18,34.38 3,14 33,14 Z" fill="#e24329"/>
+    <path d="M18,34.38 11.38,14 2,14 6,25Z" fill="#fc6d26"/>
+    <path d="M18,34.38 24.62,14 34,14 30,25Z" fill="#fc6d26"/>
+    <path d="M2 14L.1 20.16c-.18.565 0 1.2.5 1.56l17.42 12.66z" fill="#fca326"/>
+    <path d="M34 14l1.9 6.16c.18.565 0 1.2-.5 1.56L18 34.38z" fill="#fca326"/>
+  </svg>
+</svg>

--- a/chart/gitlab/overview.md
+++ b/chart/gitlab/overview.md
@@ -1,0 +1,50 @@
+## About this Helm chart
+
+This Docker Hardened Images chart is built from the official GitLab Helm chart 10.1.6 and provides a deliberately
+restricted Community Edition deployment whose default-rendered containers use only digest-pinned Docker Hardened
+Images.
+
+The chart uses:
+
+- `dhi/gitlab-webservice` for Puma, Sidekiq, dependency checks, and database migrations
+- `dhi/gitlab-workhorse`
+- `dhi/gitlab-shell`
+- `dhi/gitlab-exporter`
+- `dhi/bash` for configuration and certificate initialization
+
+GitLab's matching CNG 19.1.6 dependency and migration helper scripts are included in the chart under their MIT license.
+Small template adaptations connect the official chart's runtime contracts to the DHI entrypoints without introducing an
+unhardened helper image.
+
+### Restricted architecture
+
+This is not the upstream chart's all-in-one deployment. It requires externally operated PostgreSQL, Redis, Gitaly,
+object storage, ingress/TLS, and pre-created Kubernetes Secrets. Placeholder hosts under `example.invalid` intentionally
+fail closed until they are replaced.
+
+The following unsupported bundled components are disabled by default: internal Gitaly and Praefect, GitLab Agent Server
+(KAS), container registry, GitLab Pages, GitLab Runner, Toolbox, Geo Log Cursor, Mailroom, Prometheus, cert-manager,
+NGINX Ingress, Traefik, HAProxy, Envoy Gateway, Zoekt, OpenBao, AI Gateway, and automatic shared-secret generation.
+External optional chart dependencies are removed while packaging. Enabling an unsupported local subchart can render
+non-DHI images and is outside this chart's hardened configuration.
+
+Workhorse direct object-storage access and Redis keywatcher are disabled because the minimal DHI Workhorse image does not
+include the upstream gomplate configuration entrypoint. Object-storage traffic is proxied through Rails instead.
+
+The chart follows GitLab chart 10.1.6 (GitLab 19.1.6); the available Webservice DHI is the compatible 19.1.7 patch release
+and the Workhorse DHI is 19.1.6. Review the [guide](./guides.md) and the official GitLab chart documentation before use.
+
+## About GitLab
+
+GitLab is a DevSecOps platform for planning, source-code management, continuous integration, security, and software
+delivery. Learn more at https://about.gitlab.com/ and https://docs.gitlab.com/charts/.
+
+## About Docker Hardened Images
+
+Docker Hardened Images provide minimal, security-focused images with signed provenance, SBOMs, and VEX metadata. They are
+designed to reduce software supply-chain risk while fitting existing container workflows.
+
+## Trademarks
+
+GitLab is a trademark of GitLab Inc. Its use here is referential and does not indicate sponsorship, endorsement, or
+affiliation. Docker and Docker Hardened Images are trademarks of Docker, Inc.


### PR DESCRIPTION
## Description

Adds a Docker Hardened Images Helm chart for GitLab, based on the official GitLab chart 10.1.6 and pinned to its immutable source commit.

This is intentionally a restricted Community Edition deployment rather than an all-in-one GitLab installation. It requires externally managed PostgreSQL, Redis, Gitaly, object storage, ingress/TLS, and Kubernetes Secrets so the default render does not silently retain unsupported upstream images.

## Type of Change

- [ ] New image
- [x] New Helm chart
- [ ] New package
- [x] Documentation improvement or correction
- [ ] Example configuration or use case
- [ ] Community tooling or script
- [ ] Website or catalog enhancement
- [ ] Bug fix
- [ ] Other (please describe):

## Related Issues

Fixes #551

## Changes Made

- Add `dhi.io/gitlab-chart:10.1.6` from `gitlab-org/charts/gitlab` commit `e7cae5d54373da043fcacb75f38848cb92b72da4`.
- Use digest-pinned DHI Webservice, Workhorse, Shell, Exporter, and Bash images for every default-rendered container and Helm test.
- Disable unsupported bundled services and remove externally fetched optional chart dependencies.
- Require external stateful services and pre-created Secrets with fail-closed `example.invalid` endpoint defaults.
- Include the matching CNG 19.1.6 dependency/migration helpers under their MIT license and adapt Sidekiq, Workhorse, Shell, Exporter, certificates, and the Helm test to DHI runtime contracts.
- Document prerequisites, required/optional Secrets, unsupported component boundaries, and the Workhorse object-storage proxy behavior.

## Testing

- [x] I have tested these changes locally
- [x] All existing applicable tests pass
- [ ] I have added new tests (if applicable)

Validation performed:

- Applied the deterministic patch to a fresh checkout of the immutable upstream tag.
- `helm lint`: 1 chart linted, 0 failures.
- `helm template`: 19/19 image occurrences use digest-pinned `dhi.io` references.
- Verified all three CNG helper volumes preserve all nine required nested paths.
- Verified the Helm test uses pinned DHI Bash and renders global image pull Secrets.
- Validated `helm/10.yaml` and `info.yaml` against `.spec.json` and `.info.spec.json` with `check-jsonschema` 0.34.1.
- `git diff --check` passed.
- Full-content Aikido SAST/secrets scan returned zero issues.
- Independent review completed with no blocking findings.

Container smoke tests were attempted, but local Docker storage filled and the daemon switched read-only. Existing Docker cache was not pruned. Runtime contracts were instead checked through image definitions, entrypoint/source inspection, and rendered workload assertions; repository CI can perform the full build.

## Checklist

- [x] My changes follow the repository's style and conventions
- [x] I have updated documentation as needed
- [x] My commit messages are clear and descriptive

---

> **By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
