### PR TITLE
kargo: add hardened image proposal

### DIFF
--- a/image/kargo/debian-13/1.11-dev.yaml
+++ b/image/kargo/debian-13/1.11-dev.yaml
@@ -1,0 +1,212 @@
+# syntax=dhi.io/build:2-debian13
+
+name: Kargo 1.11.x (dev)
+image: dhi.io/kargo
+variant: dev
+tags:
+  - 1-dev
+  - 1.11-dev
+  - 1.11.2-dev
+  - 1-debian-dev
+  - 1-debian13-dev
+  - 1.11-debian-dev
+  - 1.11-debian13-dev
+  - 1.11.2-debian-dev
+  - 1.11.2-debian13-dev
+platforms:
+  - linux/amd64
+  - linux/arm64
+dates:
+  release: "2026-08-18"
+vars:
+  COMMIT_SHA: 20c56384dc3aa29911368fa9c0916e8f4a541252
+  FLAVORED_SUFFIX: -dev
+  GOLANG_REFERENCE: dhi.io/golang:1.26.7-debian13-dev@sha256:9b6a8e0bd0b59b7f4d32920da7be6dca232ebbcc52c2413b90901772f640758b
+  NODE_REFERENCE: dhi.io/node:24.20.0-debian12-dev@sha256:3d151a18796df5a421e5ef9098f26426490a9bd545be73f871358726995d2dfb
+  PNPM_VERSION: 9.0.3
+  SEMVER_MAJOR_MINOR_VERSION: "1.11"
+  SEMVER_MAJOR_VERSION: "1"
+  SEMVER_VERSION: 1.11.2
+  VERSION: 1.11.2
+contents:
+  repositories:
+    - deb [signed-by=/usr/share/keyrings/dhi-deb-main.gpg] http://dhi.io/deb/debian/main trixie main
+  keyring:
+    - https://dhi.io/keyring/dhi-deb-gpg.D46852F6925E9F71.key
+  packages:
+    - '!gawk'
+    - '!libelogind0'
+    - '!original-awk'
+    - apt
+    - base-files
+    - bash
+    - busybox
+    - ca-certificates
+    - ca-certificates-bundle
+    - coreutils
+    - curl
+    - diffutils
+    - dpkg
+    - findutils
+    - git
+    - gpg
+    - gpg-agent
+    - grep
+    - helm-3=3.21.4-1
+    - libc-bin
+    - libncursesw6
+    - libtinfo6
+    - mawk
+    - openssh-client
+    - perl-base
+    - sed
+    - tini
+    - util-linux
+  builds:
+    - name: kargo
+      uses: dhi.io/golang:1.26.7-debian13-dev@sha256:9b6a8e0bd0b59b7f4d32920da7be6dca232ebbcc52c2413b90901772f640758b
+      work-dir: /go/src/github.com/akuity/kargo
+      environment:
+        PATH: /pnpm:/usr/local/bin:/usr/local/go/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        PNPM_HOME: /pnpm
+      caches:
+        - path: /go/pkg/mod
+        - path: /pnpm/store
+      contents:
+        files:
+          - url: git+https://github.com/akuity/kargo.git#v1.11.2
+            checksum: 20c56384dc3aa29911368fa9c0916e8f4a541252
+            path: /go/src/github.com/akuity/kargo
+            spdx:
+              name: kargo
+              version: 1.11.2
+              packages:
+                - name: kargo
+                  purl: pkg:github/akuity/kargo@v1.11.2
+                  license: Apache-2.0
+            uid: 0
+            gid: 0
+        artifacts:
+          - name: dhi.io/node:24.20.0-debian12-dev@sha256:3d151a18796df5a421e5ef9098f26426490a9bd545be73f871358726995d2dfb
+            includes:
+              - opt/nodejs
+              - usr/local/bin
+            uid: 0
+            gid: 0
+      pipeline:
+        - name: build ui
+          work-dir: /go/src/github.com/akuity/kargo/ui
+          privileged: true
+          runs: |
+            set -eux -o pipefail
+
+            corepack prepare pnpm@9.0.3 --activate
+            pnpm config set store-dir /pnpm/store
+            pnpm install --frozen-lockfile
+            NODE_ENV=production VERSION=v1.11.2 pnpm run build
+            rm -rf /go/src/github.com/akuity/kargo/pkg/server/ui
+            cp -a build /go/src/github.com/akuity/kargo/pkg/server/ui
+        - name: generate ui sbom
+          uses: sbom@v1
+          with:
+            extra-scanners: javascript-package-cataloger
+            prefix: kargo-ui
+            source: /go/src/github.com/akuity/kargo/ui
+        - name: build credential helper
+          uses: go/build@v1
+          environment:
+            GOFLAGS: -trimpath -buildvcs=false
+          caches:
+            - path: /go/pkg/mod
+          with:
+            cgo_enabled: 0
+            fips: false
+            output: ${target.dir}/usr/local/bin/credential-helper
+            packages: ./cmd/credential-helper
+            strip: true
+        - name: build control plane
+          uses: go/build@v1
+          environment:
+            GOFLAGS: -trimpath -buildvcs=false
+          caches:
+            - path: /go/pkg/mod
+          with:
+            cgo_enabled: 0
+            fips: false
+            ldflags:
+              - -X github.com/akuity/kargo/pkg/x/version.version=v1.11.2
+              - -X github.com/akuity/kargo/pkg/x/version.buildDate=$(date -ud @${SOURCE_DATE_EPOCH} +'%Y-%m-%dT%H:%M:%SZ')
+              - -X github.com/akuity/kargo/pkg/x/version.gitCommit=20c56384dc3aa29911368fa9c0916e8f4a541252
+              - -X github.com/akuity/kargo/pkg/x/version.gitTreeState=clean
+            output: ${target.dir}/usr/local/bin/kargo
+            packages: ./cmd/controlplane
+            strip: true
+      outputs:
+        - source: ${target.dir}/usr/local/bin/credential-helper
+          target: /usr/local/bin/credential-helper
+          uid: 0
+          gid: 0
+          mode: "0755"
+        - source: ${target.dir}/usr/local/bin/kargo
+          target: /usr/local/bin/kargo
+          uid: 0
+          gid: 0
+          mode: "0755"
+        - source: /opt/docker/sbom/kargo
+          target: /opt/docker/sbom/kargo
+          uid: 0
+          gid: 0
+        - source: /opt/docker/sbom/kargo-ui
+          target: /opt/docker/sbom/kargo-ui
+          uid: 0
+          gid: 0
+accounts:
+  root: true
+  run-as: root
+  users:
+    - name: nonroot
+      uid: 65532
+      gid: 65532
+    - name: _apt
+      uid: 42
+      gid: 65532
+  groups:
+    - name: nonroot
+      gid: 65532
+      members:
+        - nonroot
+os-release:
+  name: Docker Hardened Images (Debian)
+  id: debian
+  version-id: "13"
+  version-codename: trixie
+  pretty-name: Docker Hardened Images/Debian GNU/Linux 13 (trixie)
+  home-url: https://docker.com/products/hardened-images/
+  bug-report-url: https://docker.com/support/
+environment:
+  DEBIAN_FRONTEND: noninteractive
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+paths:
+  - type: directory
+    path: /usr/local/bin
+    uid: 0
+    gid: 0
+  - type: symlink
+    path: /usr/local/bin/helm
+    uid: 0
+    gid: 0
+    source: /usr/bin/helm
+  - type: symlink
+    path: /sbin/tini
+    uid: 0
+    gid: 0
+    source: /usr/bin/tini
+annotations:
+  org.opencontainers.image.description: A minimal Kargo continuous promotion platform image with development tools
+  org.opencontainers.image.licenses: Apache-2.0
+entrypoint:
+  - /usr/bin/tini
+  - --
+cmd:
+  - /usr/local/bin/kargo

--- a/image/kargo/debian-13/1.11.yaml
+++ b/image/kargo/debian-13/1.11.yaml
@@ -1,0 +1,188 @@
+# syntax=dhi.io/build:2-debian13
+
+name: Kargo 1.11.x
+image: dhi.io/kargo
+variant: runtime
+tags:
+  - "1"
+  - "1.11"
+  - "1.11.2"
+  - 1-debian
+  - 1-debian13
+  - 1.11-debian
+  - 1.11-debian13
+  - 1.11.2-debian
+  - 1.11.2-debian13
+platforms:
+  - linux/amd64
+  - linux/arm64
+dates:
+  release: "2026-08-18"
+vars:
+  COMMIT_SHA: 20c56384dc3aa29911368fa9c0916e8f4a541252
+  GOLANG_REFERENCE: dhi.io/golang:1.26.7-debian13-dev@sha256:9b6a8e0bd0b59b7f4d32920da7be6dca232ebbcc52c2413b90901772f640758b
+  NODE_REFERENCE: dhi.io/node:24.20.0-debian12-dev@sha256:3d151a18796df5a421e5ef9098f26426490a9bd545be73f871358726995d2dfb
+  PNPM_VERSION: 9.0.3
+  SEMVER_MAJOR_MINOR_VERSION: "1.11"
+  SEMVER_MAJOR_VERSION: "1"
+  SEMVER_VERSION: 1.11.2
+  VERSION: 1.11.2
+contents:
+  repositories:
+    - deb [signed-by=/usr/share/keyrings/dhi-deb-main.gpg] http://dhi.io/deb/debian/main trixie main
+  keyring:
+    - https://dhi.io/keyring/dhi-deb-gpg.D46852F6925E9F71.key
+  packages:
+    - base-files
+    - busybox
+    - ca-certificates
+    - ca-certificates-bundle
+    - git
+    - gpg
+    - gpg-agent
+    - helm-3=3.21.4-1
+    - openssh-client
+    - tini
+  builds:
+    - name: kargo
+      uses: dhi.io/golang:1.26.7-debian13-dev@sha256:9b6a8e0bd0b59b7f4d32920da7be6dca232ebbcc52c2413b90901772f640758b
+      work-dir: /go/src/github.com/akuity/kargo
+      environment:
+        PATH: /pnpm:/usr/local/bin:/usr/local/go/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        PNPM_HOME: /pnpm
+      caches:
+        - path: /go/pkg/mod
+        - path: /pnpm/store
+      contents:
+        files:
+          - url: git+https://github.com/akuity/kargo.git#v1.11.2
+            checksum: 20c56384dc3aa29911368fa9c0916e8f4a541252
+            path: /go/src/github.com/akuity/kargo
+            spdx:
+              name: kargo
+              version: 1.11.2
+              packages:
+                - name: kargo
+                  purl: pkg:github/akuity/kargo@v1.11.2
+                  license: Apache-2.0
+            uid: 0
+            gid: 0
+        artifacts:
+          - name: dhi.io/node:24.20.0-debian12-dev@sha256:3d151a18796df5a421e5ef9098f26426490a9bd545be73f871358726995d2dfb
+            includes:
+              - opt/nodejs
+              - usr/local/bin
+            uid: 0
+            gid: 0
+      pipeline:
+        - name: build ui
+          work-dir: /go/src/github.com/akuity/kargo/ui
+          privileged: true
+          runs: |
+            set -eux -o pipefail
+
+            corepack prepare pnpm@9.0.3 --activate
+            pnpm config set store-dir /pnpm/store
+            pnpm install --frozen-lockfile
+            NODE_ENV=production VERSION=v1.11.2 pnpm run build
+            rm -rf /go/src/github.com/akuity/kargo/pkg/server/ui
+            cp -a build /go/src/github.com/akuity/kargo/pkg/server/ui
+        - name: generate ui sbom
+          uses: sbom@v1
+          with:
+            extra-scanners: javascript-package-cataloger
+            prefix: kargo-ui
+            source: /go/src/github.com/akuity/kargo/ui
+        - name: build credential helper
+          uses: go/build@v1
+          environment:
+            GOFLAGS: -trimpath -buildvcs=false
+          caches:
+            - path: /go/pkg/mod
+          with:
+            cgo_enabled: 0
+            fips: false
+            output: ${target.dir}/usr/local/bin/credential-helper
+            packages: ./cmd/credential-helper
+            strip: true
+        - name: build control plane
+          uses: go/build@v1
+          environment:
+            GOFLAGS: -trimpath -buildvcs=false
+          caches:
+            - path: /go/pkg/mod
+          with:
+            cgo_enabled: 0
+            fips: false
+            ldflags:
+              - -X github.com/akuity/kargo/pkg/x/version.version=v1.11.2
+              - -X github.com/akuity/kargo/pkg/x/version.buildDate=$(date -ud @${SOURCE_DATE_EPOCH} +'%Y-%m-%dT%H:%M:%SZ')
+              - -X github.com/akuity/kargo/pkg/x/version.gitCommit=20c56384dc3aa29911368fa9c0916e8f4a541252
+              - -X github.com/akuity/kargo/pkg/x/version.gitTreeState=clean
+            output: ${target.dir}/usr/local/bin/kargo
+            packages: ./cmd/controlplane
+            strip: true
+      outputs:
+        - source: ${target.dir}/usr/local/bin/credential-helper
+          target: /usr/local/bin/credential-helper
+          uid: 0
+          gid: 0
+          mode: "0755"
+        - source: ${target.dir}/usr/local/bin/kargo
+          target: /usr/local/bin/kargo
+          uid: 0
+          gid: 0
+          mode: "0755"
+        - source: /opt/docker/sbom/kargo
+          target: /opt/docker/sbom/kargo
+          uid: 0
+          gid: 0
+        - source: /opt/docker/sbom/kargo-ui
+          target: /opt/docker/sbom/kargo-ui
+          uid: 0
+          gid: 0
+accounts:
+  run-as: nonroot
+  users:
+    - name: nonroot
+      uid: 65532
+      gid: 65532
+  groups:
+    - name: nonroot
+      gid: 65532
+      members:
+        - nonroot
+os-release:
+  name: Docker Hardened Images (Debian)
+  id: debian
+  version-id: "13"
+  version-codename: trixie
+  pretty-name: Docker Hardened Images/Debian GNU/Linux 13 (trixie)
+  home-url: https://docker.com/products/hardened-images/
+  bug-report-url: https://docker.com/support/
+environment:
+  PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+  SSL_CERT_FILE: /etc/ssl/certs/ca-certificates.crt
+paths:
+  - type: directory
+    path: /usr/local/bin
+    uid: 0
+    gid: 0
+  - type: symlink
+    path: /usr/local/bin/helm
+    uid: 0
+    gid: 0
+    source: /usr/bin/helm
+  - type: symlink
+    path: /sbin/tini
+    uid: 0
+    gid: 0
+    source: /usr/bin/tini
+annotations:
+  org.opencontainers.image.description: A minimal Kargo continuous promotion platform image
+  org.opencontainers.image.licenses: Apache-2.0
+entrypoint:
+  - /usr/bin/tini
+  - --
+cmd:
+  - /usr/local/bin/kargo

--- a/image/kargo/guides.md
+++ b/image/kargo/guides.md
@@ -1,0 +1,42 @@
+## Migrate to the Docker Hardened Image
+
+Use the following image replacement for Kargo 1.11.2.
+
+| Upstream image | Docker Hardened Image |
+| --- | --- |
+| `ghcr.io/akuity/kargo:v1.11.2` | `dhi.io/kargo:1.11.2-debian13` |
+
+The runtime image runs as UID and GID `65532`. The dev variant runs as `root` and has the tag `dhi.io/kargo:1.11.2-debian13-dev`.
+
+## Use the upstream Helm chart
+
+Set the Kargo image repository and tag in the upstream chart values.
+
+```yaml
+image:
+  repository: dhi.io/kargo
+  tag: 1.11.2-debian13
+```
+
+Use the registry authentication configuration that your cluster requires for `dhi.io`. The image provides `/sbin/tini` as a compatibility link to `/usr/bin/tini`. This link supports the Kargo 1.11.2 chart templates that use `/sbin/tini` directly.
+
+The image does not declare OCI exposed ports. The chart configures ports for each role. The API server uses port `8080`. The external webhook server uses port `8080`. The Kubernetes webhook server uses port `9443`. Optional metrics services use port `9090` by default when you enable them.
+
+## Verify the image
+
+Run these checks after you pull or build the image.
+
+```console
+docker run --rm dhi.io/kargo:1.11.2-debian13 version
+docker run --rm --entrypoint /usr/bin/helm dhi.io/kargo:1.11.2-debian13 version --short
+docker run --rm --entrypoint /sbin/tini dhi.io/kargo:1.11.2-debian13 -- /usr/local/bin/kargo version
+```
+
+Inspect the OCI process configuration and confirm that the image has no exposed ports.
+
+```console
+docker image inspect dhi.io/kargo:1.11.2-debian13 \
+  --format '{{json .Config.User}} {{json .Config.Entrypoint}} {{json .Config.Cmd}} {{json .Config.ExposedPorts}}'
+```
+
+The runtime values are `nonroot`, `["/usr/bin/tini","--"]`, and `["/usr/local/bin/kargo"]`. The exposed-port value is `null`.

--- a/image/kargo/info.yaml
+++ b/image/kargo/info.yaml
@@ -1,0 +1,32 @@
+metadata:
+  display-name: Kargo
+  short-description: Kargo is a continuous promotion platform for Kubernetes.
+  featured: false
+  fips-compliant: false
+  fips-modules: []
+  stig-certified: false
+  home-url: https://kargo.io/
+  categories:
+    - integration-and-delivery
+  alternatives: []
+  included-tools:
+    - name: Kargo
+      description: Runs the Kargo control plane roles and serves the embedded web interface.
+    - name: credential-helper
+      description: Supplies credentials to Kargo Git and OCI operations.
+    - name: Helm 3
+      description: Manages Helm chart artifacts for Kargo promotion steps.
+    - name: Git
+      description: Supports Git repository operations.
+    - name: GnuPG
+      description: Supports cryptographic signing and verification for Git operations.
+    - name: OpenSSH
+      description: Supports SSH access to Git repositories.
+    - name: Tini
+      description: Provides the container init process.
+    - name: BusyBox
+      description: Provides the shell that Kargo currently requires at run time.
+advisories:
+  - type: github_advisories
+    source: akuity/kargo
+    format: github

--- a/image/kargo/overview.md
+++ b/image/kargo/overview.md
@@ -1,0 +1,15 @@
+## About Kargo
+
+[Kargo](https://kargo.io/) is a continuous promotion platform for Kubernetes. One Kargo image runs the API server, controller, management controller, external webhook server, Kubernetes webhook server, and garbage collector through Kargo subcommands.
+
+The image contains the embedded Kargo web interface. It also contains the Kargo credential helper and Helm 3. Git, GnuPG, and OpenSSH support Git and OCI workflows. BusyBox supplies the shell that Kargo currently requires. Tini runs as the container init process.
+
+The runtime image runs as the `nonroot` user with UID and GID `65532`. The dev image keeps this account but runs as `root`. The dev image adds Debian package management and common diagnostic tools. It does not include the Go or Node.js build toolchains.
+
+## About Docker Hardened Images
+
+Docker Hardened Images are minimal images with secure defaults. They include vulnerability remediation, an SBOM, and build provenance. The Kargo runtime image keeps only the operating system packages that are required for compatibility with the upstream Kargo image.
+
+## Trademarks
+
+Kargo is a project of Akuity. This image is not affiliated with or endorsed by Akuity.


### PR DESCRIPTION
## Description

Add a Docker Hardened Images catalog proposal for Akuity Kargo 1.11.2. The proposal follows the upstream `ghcr.io/akuity/kargo:v1.11.2` runtime contract and builds Kargo from its checksum-pinned source tag.

## Type of Change

- [x] New image
- [ ] New Helm chart
- [ ] New package
- [x] Documentation improvement or correction
- [ ] Example configuration or use case
- [ ] Community tooling or script
- [ ] Website or catalog enhancement
- [ ] Bug fix
- [ ] Other (please describe):

## Related Issues

Fixes #17

## Changes Made

- Add Debian 13 runtime and development image definitions for Kargo 1.11.2.
- Build the embedded UI, control-plane binary, and credential helper from source commit `20c56384dc3aa29911368fa9c0916e8f4a541252`.
- Preserve compatibility with the upstream image and Helm chart, including Helm 3, Git, GnuPG, OpenSSH, BusyBox, Tini, UID/GID 65532, and the `/sbin/tini` path.
- Add catalog metadata, overview, migration guidance, and verification commands.

## Testing

- [x] I have tested these changes locally
- [ ] All existing tests pass
- [ ] I have added new tests (if applicable)

Validation completed:

- Both image definitions pass `.spec.json` validation.
- `info.yaml` passes `.info.spec.json` validation.
- `git diff --check` passes.
- The upstream release, commit, runtime-tool, UID/GID, entrypoint, command, and no-port contracts pass bounded source checks.
- Aikido full scan reports zero issues.
- `codecov` is not installed locally.
- A full image build was not completed because the local Docker daemon did not answer `docker version` within five seconds.

## Screenshots (if applicable)

Not applicable.

## Checklist

- [x] My changes follow the repository's style and conventions
- [x] I have updated documentation as needed
- [x] My commit messages are clear and descriptive

---

> **By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.**
