### PR TITLE
cloudnative-pg-plugin-barman-cloud-sidecar: restore cloud extras dropped by barman 3.20.0

### DIFF
--- a/image/cloudnative-pg-plugin-barman-cloud-sidecar/debian-13/0-dev.yaml
+++ b/image/cloudnative-pg-plugin-barman-cloud-sidecar/debian-13/0-dev.yaml
@@ -117,7 +117,10 @@ contents:
           runs: |
             set -eux -o pipefail
 
-            "/app/.venv/bin/python3" -m pip install --no-binary=cryptography,psycopg2 --no-cache-dir ".[all]"
+            "/app/.venv/bin/python3" -m pip install --no-binary=cryptography,psycopg2 --no-cache-dir ".[argcomplete,aws-snapshots,azure,azure-snapshots,cloud,google,google-snapshots,lz4,snappy,zstandard]"
+            # pip only WARNS on an unknown extra, so a withdrawn extra name
+            # silently yields a barman with no cloud providers. Fail the build instead.
+            "/app/.venv/bin/python3" -c "import boto3, azure.storage.blob, google.cloud.storage"
         - name: upgrade cryptography for CVE fixes
           privileged: true
           runs: |

--- a/image/cloudnative-pg-plugin-barman-cloud-sidecar/debian-13/0.yaml
+++ b/image/cloudnative-pg-plugin-barman-cloud-sidecar/debian-13/0.yaml
@@ -101,7 +101,10 @@ contents:
           runs: |
             set -eux -o pipefail
 
-            "/app/.venv/bin/python3" -m pip install --no-binary=cryptography,psycopg2 --no-cache-dir ".[all]"
+            "/app/.venv/bin/python3" -m pip install --no-binary=cryptography,psycopg2 --no-cache-dir ".[argcomplete,aws-snapshots,azure,azure-snapshots,cloud,google,google-snapshots,lz4,snappy,zstandard]"
+            # pip only WARNS on an unknown extra, so a withdrawn extra name
+            # silently yields a barman with no cloud providers. Fail the build instead.
+            "/app/.venv/bin/python3" -c "import boto3, azure.storage.blob, google.cloud.storage"
         - name: upgrade cryptography for CVE fixes
           privileged: true
           runs: |


### PR DESCRIPTION
## Description

The barman venv in the sidecar image is built with `pip install ".[all]"`. barman 3.20.0 **removed** the `all` extra, and pip only *warns* on an unknown extra rather than failing, so since the 3.20.0 bump the image has shipped with none of its cloud dependencies.

Verified inside the current published image:

```
$ pip install --dry-run "barman[all]==3.20.0"
WARNING: barman 3.20.0 does not provide the extra 'all'
$ echo $?
0
```

PyPI metadata for the two versions:

| version | `provides_extra` |
|---|---|
| 3.19.1 | `all`, argcomplete, aws-snapshots, azure, azure-snapshots, cloud, google, google-snapshots, lz4, snappy, zstandard |
| 3.20.0 | argcomplete, aws-snapshots, azure, azure-snapshots, cloud, google, google-snapshots, lz4, snappy, zstandard |

Under `set -eux -o pipefail` the build still succeeds, so the regression shipped silently. `0.14.0-debian13` and `0.15.0-debian13` both currently contain **zero** botocore files, and every `barman-cloud-*` invocation fails:

```
ERROR: Barman cloud WAL archiver exception: No module named 'botocore'
```

`barman/clients/cloud_cli.py` turns that into `GeneralErrorExit`, i.e. exit status 4, which CloudNativePG surfaces as `ContinuousArchivingFailing`. The practical effect is that WAL archiving and scheduled backups stop working entirely on any deployment using this image.

Introduced by 8cf5d47ee (#91477), which bumped `BARMAN_VERSION` 3.19.1 to 3.20.0 and left the `.[all]` install untouched.

Only the sidecar image is affected. `cloudnative-pg-plugin-barman-cloud` ships no Python.

## Type of Change

- [x] Bug fix

## Related Issues

Fixes #559

## Changes Made

- Replace `.[all]` with the explicit extras list barman 3.20.0 advertises, in both `debian-13/0.yaml` and `debian-13/0-dev.yaml`.
- Add an import assertion for the three cloud providers, so a withdrawn extra fails the build instead of shipping an image with no cloud support.

## Testing

- [x] I have tested these changes locally

Built the patched install against `0.15.0-debian13` and compared the resulting Python package set with the last good build, `sha256:34b61d8dce02b075d56571605283cb7fbdfe71daea9f2b0ffa56ed1ac7655e5a`:

| | packages | missing vs last good build |
|---|---|---|
| last good build (barman 3.19.1) | 59 | n/a |
| this patch (barman 3.20.0) | 60 | none |

The one addition is `opentelemetry_api`, a new transitive dependency in 3.20.0. All three providers import, `manager --help` is unchanged, and `grype --only-fixed` reports the same zero findings as the unpatched image.

End-to-end against a live S3-compatible endpoint, `barman-cloud-backup-list` returns the real backup catalogue with the patch and fails with `No module named 'botocore'` without it.

### Note on test coverage

The image's test suite cannot be exercising a cloud provider, since any `barman-cloud-backup --cloud-provider aws-s3` call would have failed immediately. The embedded SPDX document at `/opt/docker/sbom/` also lists only the image itself and enumerates no Python packages, so no SBOM diff or vulnerability scan would have caught an entire dependency tree disappearing either. Both seem worth addressing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ExZR2a6WWvPzCzGCWVpkgN
